### PR TITLE
fix: update to go `1.22.2` due to vulnerabilities in go std library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/csaf-poc/csaf_distribution/v3
 
-go 1.22.1
+go 1.22.2
 
 require (
 	github.com/BurntSushi/toml v1.3.2


### PR DESCRIPTION
## What

fix: update to go `1.22.2` due to vulnerabilities in go std library

