### PR TITLE
use release generic workflow instead of 3rd gen release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   release:
     name: csaf_distribution
-    uses: greenbone/workflows/.github/workflows/release-3rd-gen.yml@main
+    uses: greenbone/workflows/.github/workflows/release-generic.yml@main
     with:
       release-type: ${{ inputs.release-type }}
       release-version: ${{ inputs.release-version }}


### PR DESCRIPTION
## What

use release generic workflow instead of 3rd gen release

## Why

This is just a sub component, notification of all teams via mattermost is not desired here.


