### PR TITLE
remove gofmt and go vet steps from build and test workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -21,16 +21,5 @@ jobs:
       - name: Build
         run: go build -v ./cmd/...
 
-      - name: vet
-        run: go vet ./...
-
-      - name: gofmt
-        uses: Jerome1337/gofmt-action@v1.0.4
-        with:
-          gofmt-flags: "-l -d"
-
-      - name: Revive Action
-        uses: morphy2k/revive-action@v2.5.1
-
       - name: Tests
         run: go test -v ./...


### PR DESCRIPTION
## What

remove gofmt and go vet steps from build and test workflow

## Why

We have checks in other actions and it conflicts with the auto generated `version.go` file.


