### PR TITLE
update go version to `1.22.4`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/csaf-poc/csaf_distribution/v3
 
-go 1.22.2
+go 1.22.4
 
 require (
 	github.com/BurntSushi/toml v1.3.2


### PR DESCRIPTION
## What

Update go version

## Why

Fix Vulnerabilities on older version of go standard library.
