### PR TITLE
fix: update go version to `1.22.5`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/csaf-poc/csaf_distribution/v3
 
-go 1.22.4
+go 1.22.5
 
 require (
 	github.com/BurntSushi/toml v1.4.0


### PR DESCRIPTION
## What

Update go version to `1.22.5`

## Why

Fix vulnerabilities in golang std library.


