### PR TITLE
update go version to `1.23.1`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/csaf-poc/csaf_distribution/v3
 
-go 1.22.5
+go 1.23.1
 
 require (
 	github.com/BurntSushi/toml v1.4.0


### PR DESCRIPTION
## What

update go version to `1.23.1`

## Why

Requirement by some dependency. And anyways we want to use the latest version.

