### PR TITLE
fix: return valid byte slice on csaf channel

### DIFF
--- a/cmd/csaf_downloader/downloader.go
+++ b/cmd/csaf_downloader/downloader.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -678,7 +679,8 @@ nextAdvisory:
 		}
 
 		if d.cfg.ForwardChannel {
-			d.Csafs <- data.Bytes()
+			// the bytes slice is modified by the next buffer modification, so we need to copy it
+			d.Csafs <- slices.Clone(data.Bytes())
 		}
 
 		if d.cfg.NoStore {


### PR DESCRIPTION
## What

Send a newly created byte slice with the csaf document content on the channel. Previously the sent byte slice was gained from the method `Buffer.Bytes()`. However this "slice is valid for use only until the next buffer modification" and therefore modified with the next buffer modification..

## Why

The bug caused a data race. If the receiver is not processing the content from the channel fast enough, the content of the returned byte slice is overwritten by the next downloaded CSAF.

