### PR TITLE
Add upstream changes

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,11 +24,5 @@ jobs:
       - name: vet
         run: go vet ./...
 
-      - name: golint
-        uses: Jerome1337/golint-action@v1.0.3
-
-      - name: Revive Action
-        uses: morphy2k/revive-action@v2.7.4
-
       - name: Tests
         run: go test -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,10 +16,24 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 'stable'
+          go-version: "stable"
 
       - name: Build
         run: go build -v ./cmd/...
+
+      - name: vet
+        run: go vet ./...
+
+      - name: gofmt
+        uses: Jerome1337/gofmt-action@v1.0.4
+        with:
+          gofmt-flags: "-l -d"
+
+      - name: golint
+        uses: Jerome1337/golint-action@v1.0.3
+
+      - name: Revive Action
+        uses: morphy2k/revive-action@v2.7.4
 
       - name: Tests
         run: go test -v ./...

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,11 +24,6 @@ jobs:
       - name: vet
         run: go vet ./...
 
-      - name: gofmt
-        uses: Jerome1337/gofmt-action@v1.0.4
-        with:
-          gofmt-flags: "-l -d"
-
       - name: golint
         uses: Jerome1337/golint-action@v1.0.3
 

--- a/cmd/csaf_aggregator/client_test.go
+++ b/cmd/csaf_aggregator/client_test.go
@@ -49,10 +49,10 @@ func Test_downloadJSON(t *testing.T) {
 		test := testToRun
 		t.Run(test.name, func(tt *testing.T) {
 			tt.Parallel()
-			found := func(r io.Reader) error {
+			found := func(_ io.Reader) error {
 				return nil
 			}
-			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 				w.Header().Add("Content-Type", test.contentType)
 				w.WriteHeader(test.statusCode)
 			}))

--- a/cmd/csaf_aggregator/config.go
+++ b/cmd/csaf_aggregator/config.go
@@ -264,8 +264,14 @@ func (c *config) privateOpenPGPKey() (*crypto.Key, error) {
 	return c.key, c.keyErr
 }
 
-func (c *config) httpClient(p *provider) util.Client {
+// httpLog does structured logging in a [util.LoggingClient].
+func httpLog(method, url string) {
+	slog.Debug("http",
+		"method", method,
+		"url", url)
+}
 
+func (c *config) httpClient(p *provider) util.Client {
 	hClient := http.Client{}
 
 	var tlsConfig tls.Config
@@ -310,7 +316,10 @@ func (c *config) httpClient(p *provider) util.Client {
 	}
 
 	if c.Verbose {
-		client = &util.LoggingClient{Client: client}
+		client = &util.LoggingClient{
+			Client: client,
+			Log:    httpLog,
+		}
 	}
 
 	if p.Rate == nil && c.Rate == nil {
@@ -331,7 +340,6 @@ func (c *config) httpClient(p *provider) util.Client {
 }
 
 func (c *config) checkProviders() error {
-
 	if !c.AllowSingleProvider && len(c.Providers) < 2 {
 		return errors.New("need at least two providers")
 	}
@@ -471,7 +479,6 @@ func (c *config) prepareCertificates() error {
 
 // prepare prepares internal state of a loaded configuration.
 func (c *config) prepare() error {
-
 	if len(c.Providers) == 0 {
 		return errors.New("no providers given in configuration")
 	}

--- a/cmd/csaf_aggregator/mirror.go
+++ b/cmd/csaf_aggregator/mirror.go
@@ -462,8 +462,9 @@ func (w *worker) extractCategories(label string, advisory any) error {
 			expr := cat[len(exprPrefix):]
 			// Compile first to check that the expression is okay.
 			if _, err := w.expr.Compile(expr); err != nil {
-				fmt.Printf("Compiling category expression %q failed: %v\n",
-					expr, err)
+				slog.Error("Compiling category expression failed",
+					"expr", expr,
+					"err", err)
 				continue
 			}
 			// Ignore errors here as they result from not matching.
@@ -588,12 +589,10 @@ func (w *worker) mirrorFiles(tlpLabel csaf.TLPLabel, files []csaf.AdvisoryFile) 
 			if err := os.MkdirAll(yearDir, 0755); err != nil {
 				return err
 			}
-			//log.Printf("created %s\n", yearDir)
 			yearDirs[year] = yearDir
 		}
 
 		fname := filepath.Join(yearDir, filename)
-		//log.Printf("write: %s\n", fname)
 		data := content.Bytes()
 		if err := writeFileHashes(
 			fname, filename,

--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -53,6 +53,8 @@ type processor struct {
 	pmd            any
 	keys           *crypto.KeyRing
 	labelChecker   labelChecker
+	timesChanges   map[string]time.Time
+	timesAdv       map[string]time.Time
 
 	invalidAdvisories      topicMessages
 	badFilenames           topicMessages
@@ -188,6 +190,9 @@ func newProcessor(cfg *config) (*processor, error) {
 			advisories:      map[csaf.TLPLabel]util.Set[string]{},
 			whiteAdvisories: map[identifier]bool{},
 		},
+		timesAdv:     map[string]time.Time{},
+		timesChanges: map[string]time.Time{},
+		noneTLS:      util.Set[string]{},
 	}, nil
 }
 
@@ -202,14 +207,14 @@ func (p *processor) close() {
 // reset clears the fields values of the given processor.
 func (p *processor) reset() {
 	p.redirects = nil
-	p.noneTLS = nil
-	for k := range p.alreadyChecked {
-		delete(p.alreadyChecked, k)
-	}
 	p.pmdURL = ""
 	p.pmd256 = nil
 	p.pmd = nil
 	p.keys = nil
+	clear(p.alreadyChecked)
+	clear(p.noneTLS)
+	clear(p.timesAdv)
+	clear(p.timesChanges)
 
 	p.invalidAdvisories.reset()
 	p.badFilenames.reset()
@@ -371,9 +376,6 @@ func (p *processor) checkDomain(domain string) error {
 // checkTLS parses the given URL to check its schema, as a result it sets
 // the value of "noneTLS" field if it is not HTTPS.
 func (p *processor) checkTLS(u string) {
-	if p.noneTLS == nil {
-		p.noneTLS = util.Set[string]{}
-	}
 	if x, err := url.Parse(u); err == nil && x.Scheme != "https" {
 		p.noneTLS.Add(u)
 	}
@@ -617,6 +619,8 @@ func makeAbsolute(base *url.URL) func(*url.URL) *url.URL {
 
 var yearFromURL = regexp.MustCompile(`.*/(\d{4})/[^/]+$`)
 
+// integrity checks several csaf.AdvisoryFiles for formal
+// mistakes, from conforming filenames to invalid advisories.
 func (p *processor) integrity(
 	files []csaf.AdvisoryFile,
 	base string,
@@ -678,9 +682,9 @@ func (p *processor) integrity(
 			continue
 		}
 
-		// Warn if we do not get JSON.
+		// Error if we do not get JSON.
 		if ct := res.Header.Get("Content-Type"); ct != "application/json" {
-			lg(WarnType,
+			lg(ErrorType,
 				"The content type of %s should be 'application/json' but is '%s'",
 				u, ct)
 		}
@@ -732,19 +736,19 @@ func (p *processor) integrity(
 		// Check if file is in the right folder.
 		p.badFolders.use()
 
-		if date, err := p.expr.Eval(
-			`$.document.tracking.initial_release_date`, doc); err != nil {
-			p.badFolders.error(
-				"Extracting 'initial_release_date' from %s failed: %v", u, err)
-		} else if text, ok := date.(string); !ok {
-			p.badFolders.error("'initial_release_date' is not a string in %s", u)
-		} else if d, err := time.Parse(time.RFC3339, text); err != nil {
-			p.badFolders.error(
-				"Parsing 'initial_release_date' as RFC3339 failed in %s: %v", u, err)
-		} else if folderYear == nil {
+		switch date, fault := p.extractTime(doc, `initial_release_date`, u); {
+		case fault != "":
+			p.badFolders.error(fault)
+		case folderYear == nil:
 			p.badFolders.error("No year folder found in %s", u)
-		} else if d.UTC().Year() != *folderYear {
-			p.badFolders.error("%s should be in folder %d", u, d.UTC().Year())
+		case date.UTC().Year() != *folderYear:
+			p.badFolders.error("%s should be in folder %d", u, date.UTC().Year())
+		}
+		current, fault := p.extractTime(doc, `current_release_date`, u)
+		if fault != "" {
+			p.badChanges.error(fault)
+		} else {
+			p.timesAdv[f.URL()] = current
 		}
 
 		// Check hashes
@@ -861,7 +865,46 @@ func (p *processor) integrity(
 		}
 	}
 
+	// If we tested an existing changes.csv
+	if len(p.timesAdv) > 0 && p.badChanges.used() {
+		// Iterate over all files again
+		for _, f := range files {
+			// If there was no previous error when extracting times from advisories and we have a valid time
+			if timeAdv, ok := p.timesAdv[f.URL()]; ok {
+				// If there was no previous error when extracting times from changes and the file was listed in changes.csv
+				if timeCha, ok := p.timesChanges[f.URL()]; ok {
+					// check if the time matches
+					if !timeAdv.Equal(timeCha) {
+						// if not, give an error and remove the pair so it isn't reported multiple times should integrity be called again
+						p.badChanges.error("Current release date in changes.csv and %s is not identical.", f.URL())
+						delete(p.timesAdv, f.URL())
+						delete(p.timesChanges, f.URL())
+					}
+				}
+			}
+		}
+	}
+
 	return nil
+}
+
+// extractTime extracts a time.Time value from a json document and returns it and an empty string or zero time alongside
+// a string representing the error message that prevented obtaining the proper time value.
+func (p *processor) extractTime(doc any, value string, u any) (time.Time, string) {
+	filter := "$.document.tracking." + value
+	date, err := p.expr.Eval(filter, doc)
+	if err != nil {
+		return time.Time{}, fmt.Sprintf("Extracting '%s' from %s failed: %v", value, u, err)
+	}
+	text, ok := date.(string)
+	if !ok {
+		return time.Time{}, fmt.Sprintf("'%s' is not a string in %s", value, u)
+	}
+	d, err := time.Parse(time.RFC3339, text)
+	if err != nil {
+		return time.Time{}, fmt.Sprintf("Parsing '%s' as RFC3339 failed in %s: %v", value, u, err)
+	}
+	return d, ""
 }
 
 // checkIndex fetches the "index.txt" and calls "checkTLS" method for HTTPS checks.
@@ -991,8 +1034,10 @@ func (p *processor) checkChanges(base string, mask whereType) error {
 			}
 			path := r[pathColumn]
 
-			times, files = append(times, t),
+			times, files =
+				append(times, t),
 				append(files, csaf.DirectoryAdvisoryFile{Path: path})
+			p.timesChanges[path] = t
 		}
 		return times, files, nil
 	}()

--- a/cmd/csaf_downloader/downloader.go
+++ b/cmd/csaf_downloader/downloader.go
@@ -64,7 +64,6 @@ type Downloader struct {
 const failedValidationDir = "failed_validation"
 
 func NewDownloader(cfg *Config) (*Downloader, error) {
-
 	var validator csaf.RemoteValidator
 
 	if cfg.RemoteValidator != "" {
@@ -116,7 +115,6 @@ func logRedirect(req *http.Request, via []*http.Request) error {
 }
 
 func (d *Downloader) httpClient() util.Client {
-
 	hClient := http.Client{}
 
 	if d.cfg.verbose() {
@@ -426,6 +424,349 @@ func (d *Downloader) logValidationIssues(url string, errors []string, err error)
 	}
 }
 
+// downloadContext stores the common context of a downloader.
+type downloadContext struct {
+	d                  *Downloader
+	client             util.Client
+	data               bytes.Buffer
+	lastDir            string
+	initialReleaseDate time.Time
+	dateExtract        func(any) error
+	lower              string
+	stats              stats
+	expr               *util.PathEval
+}
+
+func newDownloadContext(d *Downloader, label csaf.TLPLabel) *downloadContext {
+	dc := &downloadContext{
+		d:      d,
+		client: d.httpClient(),
+		lower:  strings.ToLower(string(label)),
+		expr:   util.NewPathEval(),
+	}
+	dc.dateExtract = util.TimeMatcher(&dc.initialReleaseDate, time.RFC3339)
+	return dc
+}
+
+func (dc *downloadContext) downloadAdvisory(
+	file csaf.AdvisoryFile,
+	errorCh chan<- error,
+) error {
+	u, err := url.Parse(file.URL())
+	if err != nil {
+		dc.stats.downloadFailed++
+		slog.Warn("Ignoring invalid URL",
+			"url", file.URL(),
+			"error", err)
+		return nil
+	}
+
+	if dc.d.cfg.ignoreURL(file.URL()) {
+		slog.Debug("Ignoring URL", "url", file.URL())
+		return nil
+	}
+
+	// Ignore not conforming filenames.
+	filename := filepath.Base(u.Path)
+	if !util.ConformingFileName(filename) {
+		dc.stats.filenameFailed++
+		errorCh <- csafErrs.ErrInvalidCsaf{Message: fmt.Sprintf("CSAF has non conforming filename %s", filename)}
+		slog.Warn("Ignoring none conforming filename",
+			"filename", filename)
+		return nil
+	}
+
+	resp, err := dc.client.Get(file.URL())
+	if err != nil {
+		dc.stats.downloadFailed++
+		errorCh <- csafErrs.ErrNetwork{Message: fmt.Sprintf("can't retrieve CSAF document %s from URL %s: %v", filename, file.URL(), err)}
+		slog.Warn("Cannot GET",
+			"url", file.URL(),
+			"error", err)
+		return nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		switch {
+		case resp.StatusCode == http.StatusUnauthorized:
+			errorCh <- csafErrs.ErrInvalidCredentials{Message: fmt.Sprintf("invalid credentials to retrieve CSAF document %s at URL %s: %s", filename, file.URL(), resp.Status)}
+		case resp.StatusCode == http.StatusNotFound:
+			errorCh <- csafErrs.ErrCsafProviderIssue{Message: fmt.Sprintf("could not find CSAF document %s listed in table of content at URL %s: %s ", filename, file.URL(), resp.Status)}
+		case resp.StatusCode >= 500:
+			errorCh <- fmt.Errorf("could not retrieve CSAF document %s at URL %s: %s %w", filename, file.URL(), resp.Status, csafErrs.ErrRetryable) // mark as retryable error
+		default:
+			errorCh <- fmt.Errorf("could not retrieve CSAF document %s at URL %s: %s", filename, file.URL(), resp.Status)
+		}
+		dc.stats.downloadFailed++
+		slog.Warn("Cannot load",
+			"url", file.URL(),
+			"status", resp.Status,
+			"status_code", resp.StatusCode)
+		return nil
+	}
+
+	// Warn if we do not get JSON.
+	if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
+		slog.Warn("Content type is not 'application/json'",
+			"url", file.URL(),
+			"content_type", ct)
+	}
+
+	var (
+		writers                    []io.Writer
+		s256, s512                 hash.Hash
+		s256Data, s512Data         []byte
+		remoteSHA256, remoteSHA512 []byte
+		signData                   []byte
+	)
+
+	hashToFetch := []hashFetchInfo{}
+	if file.SHA512URL() != "" {
+		hashToFetch = append(hashToFetch, hashFetchInfo{
+			url:       file.SHA512URL(),
+			warn:      true,
+			hashType:  algSha512,
+			preferred: strings.EqualFold(string(dc.d.cfg.PreferredHash), string(algSha512)),
+		})
+	} else {
+		slog.Info("SHA512 not present")
+	}
+	if file.SHA256URL() != "" {
+		hashToFetch = append(hashToFetch, hashFetchInfo{
+			url:       file.SHA256URL(),
+			warn:      true,
+			hashType:  algSha256,
+			preferred: strings.EqualFold(string(dc.d.cfg.PreferredHash), string(algSha256)),
+		})
+	} else {
+		slog.Info("SHA256 not present")
+	}
+	if file.IsDirectory() {
+		for i := range hashToFetch {
+			hashToFetch[i].warn = false
+		}
+	}
+
+	remoteSHA256, s256Data, remoteSHA512, s512Data = loadHashes(dc.client, hashToFetch)
+	if remoteSHA512 != nil {
+		s512 = sha512.New()
+		writers = append(writers, s512)
+	}
+	if remoteSHA256 != nil {
+		s256 = sha256.New()
+		writers = append(writers, s256)
+	}
+
+	// Remember the data as we need to store it to file later.
+	dc.data.Reset()
+	writers = append(writers, &dc.data)
+
+	// Download the advisory and hash it.
+	hasher := io.MultiWriter(writers...)
+
+	var doc any
+
+	tee := io.TeeReader(resp.Body, hasher)
+
+	if err := json.NewDecoder(tee).Decode(&doc); err != nil {
+		dc.stats.downloadFailed++
+		errorCh <- csafErrs.ErrInvalidCsaf{Message: fmt.Sprintf("CSAF document %s at URL %s is not valid json: %v", filename, file.URL(), err)}
+		slog.Warn("Downloading failed",
+			"url", file.URL(),
+			"error", err)
+		return nil
+	}
+
+	// Compare the checksums.
+	s256Check := func() error {
+		if s256 != nil && !bytes.Equal(s256.Sum(nil), remoteSHA256) {
+			dc.stats.sha256Failed++
+			errorCh <- csafErrs.ErrCsafProviderIssue{Message: fmt.Sprintf("SHA256 checksum of CSAF document %s at URL %s does not match", filename, file.URL())}
+			return fmt.Errorf("SHA256 checksum of %s does not match", file.URL())
+		}
+		return nil
+	}
+
+	s512Check := func() error {
+		if s512 != nil && !bytes.Equal(s512.Sum(nil), remoteSHA512) {
+			dc.stats.sha512Failed++
+			errorCh <- csafErrs.ErrCsafProviderIssue{Message: fmt.Sprintf("SHA512 checksum of CSAF document %s at URL %s does not match", filename, file.URL())}
+			return fmt.Errorf("SHA512 checksum of %s does not match", file.URL())
+		}
+		return nil
+	}
+
+	// Validate OpenPGP signature.
+	keysCheck := func() error {
+		// Only check signature if we have loaded keys.
+		if dc.d.keys == nil {
+			return nil
+		}
+		var sign *crypto.PGPSignature
+		sign, signData, err = loadSignature(dc.client, file.SignURL())
+		if err != nil {
+			slog.Warn("Downloading signature failed",
+				"url", file.SignURL(),
+				"error", err)
+		}
+		if sign != nil {
+			if err := dc.d.checkSignature(dc.data.Bytes(), sign); err != nil {
+				if !dc.d.cfg.IgnoreSignatureCheck {
+					dc.stats.signatureFailed++
+					errorCh <- csafErrs.ErrCsafProviderIssue{Message: fmt.Sprintf("cannot verify signature for CSAF document %s at URL %s: %v", filename, file.URL(), err)}
+					return fmt.Errorf("cannot verify signature for %s: %v", file.URL(), err)
+				}
+			}
+		}
+		return nil
+	}
+
+	// Validate against CSAF schema.
+	schemaCheck := func() error {
+		if errors, err := csaf.ValidateCSAF(doc); err != nil || len(errors) > 0 {
+			dc.stats.schemaFailed++
+			if err != nil {
+				errorCh <- fmt.Errorf("schema validation for CSAF document %s failed: %w", filename, err)
+			} else {
+				errorCh <- csafErrs.ErrInvalidCsaf{Message: fmt.Sprintf("CSAF document %s at URL %s does not conform to JSON schema: %v", filename, file.URL(), errors)}
+			}
+			dc.d.logValidationIssues(file.URL(), errors, err)
+			return fmt.Errorf("schema validation for %q failed", file.URL())
+		}
+		return nil
+	}
+
+	// Validate if filename is conforming.
+	filenameCheck := func() error {
+		if err := util.IDMatchesFilename(dc.expr, doc, filename); err != nil {
+			dc.stats.filenameFailed++
+			errorCh <- csafErrs.ErrInvalidCsaf{Message: fmt.Sprintf("invalid CSAF document %s at URL %s: %v", filename, file.URL(), err)}
+			return fmt.Errorf("filename not conforming %s: %s", file.URL(), err)
+		}
+		return nil
+	}
+
+	// Validate against remote validator.
+	remoteValidatorCheck := func() error {
+		if dc.d.validator == nil {
+			return nil
+		}
+		rvr, err := dc.d.validator.Validate(doc)
+		if err != nil {
+			errorCh <- fmt.Errorf(
+				"calling remote validator on %q failed: %w",
+				file.URL(), err)
+			return nil
+		}
+		if !rvr.Valid {
+			dc.stats.remoteFailed++
+			errorCh <- csafErrs.ErrInvalidCsaf{Message: fmt.Sprintf("remote validation of CSAF document %s at URL %s failed", filename, file.URL())}
+			return fmt.Errorf("remote validation of %q failed", file.URL())
+		}
+		return nil
+	}
+
+	// Run all the validations.
+	valStatus := notValidatedValidationStatus
+	for _, check := range []func() error{
+		s256Check,
+		s512Check,
+		keysCheck,
+		schemaCheck,
+		filenameCheck,
+		remoteValidatorCheck,
+	} {
+		if err := check(); err != nil {
+			slog.Error("Validation check failed", "error", err)
+			valStatus.update(invalidValidationStatus)
+			if dc.d.cfg.ValidationMode == ValidationStrict {
+				return nil
+			}
+		}
+	}
+	valStatus.update(validValidationStatus)
+
+	// Send to forwarder
+	if dc.d.Forwarder != nil {
+		dc.d.Forwarder.forward(
+			filename, dc.data.String(),
+			valStatus,
+			string(s256Data),
+			string(s512Data))
+	}
+
+	if dc.d.cfg.ForwardChannel {
+		// the bytes slice is modified by the next buffer modification, so we need to copy it
+		dc.d.Csafs <- slices.Clone(dc.data.Bytes())
+	}
+
+	if dc.d.cfg.NoStore {
+		// Do not write locally.
+		if valStatus == validValidationStatus {
+			dc.stats.succeeded++
+		}
+		return nil
+	}
+
+	if err := dc.expr.Extract(
+		`$.document.tracking.initial_release_date`, dc.dateExtract, false, doc,
+	); err != nil {
+		slog.Warn("Cannot extract initial_release_date from advisory",
+			"url", file.URL())
+		dc.initialReleaseDate = time.Now()
+	}
+	dc.initialReleaseDate = dc.initialReleaseDate.UTC()
+
+	// Advisories that failed validation are stored in a special folder.
+	var newDir string
+	if valStatus != validValidationStatus {
+		newDir = path.Join(dc.d.cfg.Directory, failedValidationDir)
+	} else {
+		newDir = dc.d.cfg.Directory
+	}
+
+	// Do we have a configured destination folder?
+	if dc.d.cfg.Folder != "" {
+		newDir = path.Join(newDir, dc.d.cfg.Folder)
+	} else {
+		newDir = path.Join(newDir, dc.lower, strconv.Itoa(dc.initialReleaseDate.Year()))
+	}
+
+	if newDir != dc.lastDir {
+		if err := dc.d.mkdirAll(newDir, 0755); err != nil {
+			errorCh <- err
+			return nil
+		}
+		dc.lastDir = newDir
+	}
+
+	// Write advisory to file
+	path := filepath.Join(dc.lastDir, filename)
+
+	// Write data to disk.
+	for _, x := range []struct {
+		p string
+		d []byte
+	}{
+		{path, dc.data.Bytes()},
+		{path + ".sha256", s256Data},
+		{path + ".sha512", s512Data},
+		{path + ".asc", signData},
+	} {
+		if x.d != nil {
+			if err := os.WriteFile(x.p, x.d, 0644); err != nil {
+				errorCh <- err
+				return nil
+			}
+		}
+	}
+
+	dc.stats.succeeded++
+	slog.Info("Written advisory", "path", path)
+	return nil
+}
+
 func (d *Downloader) downloadWorker(
 	ctx context.Context,
 	wg *sync.WaitGroup,
@@ -435,21 +776,11 @@ func (d *Downloader) downloadWorker(
 ) {
 	defer wg.Done()
 
-	var (
-		client             = d.httpClient()
-		data               bytes.Buffer
-		lastDir            string
-		initialReleaseDate time.Time
-		dateExtract        = util.TimeMatcher(&initialReleaseDate, time.RFC3339)
-		lower              = strings.ToLower(string(label))
-		stats              = stats{}
-		expr               = util.NewPathEval()
-	)
+	dc := newDownloadContext(d, label)
 
 	// Add collected stats back to total.
-	defer d.addStats(&stats)
+	defer d.addStats(&dc.stats)
 
-nextAdvisory:
 	for {
 		var file csaf.AdvisoryFile
 		var ok bool
@@ -461,329 +792,10 @@ nextAdvisory:
 		case <-ctx.Done():
 			return
 		}
-
-		u, err := url.Parse(file.URL())
-		if err != nil {
-			stats.downloadFailed++
-			slog.Warn("Ignoring invalid URL",
-				"url", file.URL(),
-				"error", err)
-			continue
+		if err := dc.downloadAdvisory(file, errorCh); err != nil {
+			slog.Error("download terminated", "error", err)
+			return
 		}
-
-		if d.cfg.ignoreURL(file.URL()) {
-			slog.Debug("Ignoring URL", "url", file.URL())
-			continue
-		}
-
-		// Ignore not conforming filenames.
-		filename := filepath.Base(u.Path)
-		if !util.ConformingFileName(filename) {
-			stats.filenameFailed++
-			errorCh <- csafErrs.ErrInvalidCsaf{Message: fmt.Sprintf("CSAF has non conforming filename %s", filename)}
-			slog.Warn("Ignoring none conforming filename",
-				"filename", filename)
-			continue
-		}
-
-		resp, err := client.Get(file.URL())
-		if err != nil {
-			stats.downloadFailed++
-			errorCh <- csafErrs.ErrNetwork{Message: fmt.Sprintf("can't retrieve CSAF document %s from URL %s: %v", filename, file.URL(), err)}
-			slog.Warn("Cannot GET",
-				"url", file.URL(),
-				"error", err)
-			continue
-		}
-		responseBody, err := io.ReadAll(resp.Body)
-		resp.Body.Close()
-		if err != nil {
-			stats.downloadFailed++
-			errorCh <- csafErrs.ErrNetwork{Message: fmt.Sprintf("can't read response body containing CSAF document %s from URL %s: %v", filename, file.URL(), err)}
-			slog.Warn("Cannot read response body",
-				"url", file.URL(),
-				"error", err)
-			continue
-		}
-
-		if resp.StatusCode != http.StatusOK {
-			switch {
-			case resp.StatusCode == http.StatusUnauthorized:
-				errorCh <- csafErrs.ErrInvalidCredentials{Message: fmt.Sprintf("invalid credentials to retrieve CSAF document %s at URL %s: %s", filename, file.URL(), resp.Status)}
-			case resp.StatusCode == http.StatusNotFound:
-				errorCh <- csafErrs.ErrCsafProviderIssue{Message: fmt.Sprintf("could not find CSAF document %s listed in table of content at URL %s: %s ", filename, file.URL(), resp.Status)}
-			case resp.StatusCode >= 500:
-				errorCh <- fmt.Errorf("could not retrieve CSAF document %s at URL %s: %s %w", filename, file.URL(), resp.Status, csafErrs.ErrRetryable) // mark as retryable error
-			default:
-				errorCh <- fmt.Errorf("could not retrieve CSAF document %s at URL %s: %s", filename, file.URL(), resp.Status)
-			}
-			stats.downloadFailed++
-			slog.Warn("Cannot load",
-				"url", file.URL(),
-				"status", resp.Status,
-				"status_code", resp.StatusCode)
-			continue
-		}
-
-		// Warn if we do not get JSON.
-		if ct := resp.Header.Get("Content-Type"); ct != "application/json" {
-			slog.Warn("Content type is not 'application/json'",
-				"url", file.URL(),
-				"content_type", ct)
-		}
-
-		var (
-			writers                    []io.Writer
-			s256, s512                 hash.Hash
-			s256Data, s512Data         []byte
-			remoteSHA256, remoteSHA512 []byte
-			signData                   []byte
-		)
-
-		hashToFetch := []hashFetchInfo{}
-		if file.SHA512URL() != "" {
-			hashToFetch = append(hashToFetch, hashFetchInfo{
-				url:       file.SHA512URL(),
-				warn:      true,
-				hashType:  algSha512,
-				preferred: strings.EqualFold(string(d.cfg.PreferredHash), string(algSha512)),
-			})
-		} else {
-			slog.Info("SHA512 not present")
-		}
-		if file.SHA256URL() != "" {
-			hashToFetch = append(hashToFetch, hashFetchInfo{
-				url:       file.SHA256URL(),
-				warn:      true,
-				hashType:  algSha256,
-				preferred: strings.EqualFold(string(d.cfg.PreferredHash), string(algSha256)),
-			})
-		} else {
-			slog.Info("SHA256 not present")
-		}
-		if file.IsDirectory() {
-			for i := range hashToFetch {
-				hashToFetch[i].warn = false
-			}
-		}
-
-		remoteSHA256, s256Data, remoteSHA512, s512Data = loadHashes(client, hashToFetch)
-		if remoteSHA512 != nil {
-			s512 = sha512.New()
-			writers = append(writers, s512)
-		}
-		if remoteSHA256 != nil {
-			s256 = sha256.New()
-			writers = append(writers, s256)
-		}
-
-		// Remember the data as we need to store it to file later.
-		data.Reset()
-		writers = append(writers, &data)
-
-		// Download the advisory and hash it.
-		hasher := io.MultiWriter(writers...)
-
-		var doc any
-
-		if err := func() error {
-			tee := io.TeeReader(bytes.NewReader(responseBody), hasher)
-			return json.NewDecoder(tee).Decode(&doc)
-		}(); err != nil {
-			stats.downloadFailed++
-			errorCh <- csafErrs.ErrInvalidCsaf{Message: fmt.Sprintf("CSAF document %s at URL %s is not valid json: %v", filename, file.URL(), err)}
-			slog.Warn("Downloading failed",
-				"url", file.URL(),
-				"error", err)
-			continue
-		}
-
-		// Compare the checksums.
-		s256Check := func() error {
-			if s256 != nil && !bytes.Equal(s256.Sum(nil), remoteSHA256) {
-				stats.sha256Failed++
-				errorCh <- csafErrs.ErrCsafProviderIssue{Message: fmt.Sprintf("SHA256 checksum of CSAF document %s at URL %s does not match", filename, file.URL())}
-				return fmt.Errorf("SHA256 checksum of %s does not match", file.URL())
-			}
-			return nil
-		}
-
-		s512Check := func() error {
-			if s512 != nil && !bytes.Equal(s512.Sum(nil), remoteSHA512) {
-				stats.sha512Failed++
-				errorCh <- csafErrs.ErrCsafProviderIssue{Message: fmt.Sprintf("SHA512 checksum of CSAF document %s at URL %s does not match", filename, file.URL())}
-				return fmt.Errorf("SHA512 checksum of %s does not match", file.URL())
-			}
-			return nil
-		}
-
-		// Validate OpenPGP signature.
-		keysCheck := func() error {
-			// Only check signature if we have loaded keys.
-			if d.keys == nil {
-				return nil
-			}
-			var sign *crypto.PGPSignature
-			sign, signData, err = loadSignature(client, file.SignURL())
-			if err != nil {
-				slog.Warn("Downloading signature failed",
-					"url", file.SignURL(),
-					"error", err)
-			}
-			if sign != nil {
-				if err := d.checkSignature(data.Bytes(), sign); err != nil {
-					if !d.cfg.IgnoreSignatureCheck {
-						stats.signatureFailed++
-						errorCh <- csafErrs.ErrCsafProviderIssue{Message: fmt.Sprintf("cannot verify signature for CSAF document %s at URL %s: %v", filename, file.URL(), err)}
-						return fmt.Errorf("cannot verify signature for %s: %v", file.URL(), err)
-					}
-				}
-			}
-			return nil
-		}
-
-		// Validate against CSAF schema.
-		schemaCheck := func() error {
-			if errors, err := csaf.ValidateCSAF(doc); err != nil || len(errors) > 0 {
-				stats.schemaFailed++
-				if err != nil {
-					errorCh <- fmt.Errorf("schema validation for CSAF document %s failed: %w", filename, err)
-				} else {
-					errorCh <- csafErrs.ErrInvalidCsaf{Message: fmt.Sprintf("CSAF document %s at URL %s does not conform to JSON schema: %v", filename, file.URL(), errors)}
-				}
-				d.logValidationIssues(file.URL(), errors, err)
-				return fmt.Errorf("schema validation for %q failed", file.URL())
-			}
-			return nil
-		}
-
-		// Validate if filename is conforming.
-		filenameCheck := func() error {
-			if err := util.IDMatchesFilename(expr, doc, filename); err != nil {
-				stats.filenameFailed++
-				errorCh <- csafErrs.ErrInvalidCsaf{Message: fmt.Sprintf("invalid CSAF document %s at URL %s: %v", filename, file.URL(), err)}
-				return fmt.Errorf("filename not conforming %s: %s", file.URL(), err)
-			}
-			return nil
-		}
-
-		// Validate against remote validator.
-		remoteValidatorCheck := func() error {
-			if d.validator == nil {
-				return nil
-			}
-			rvr, err := d.validator.Validate(doc)
-			if err != nil {
-				errorCh <- fmt.Errorf(
-					"calling remote validator on %q failed: %w",
-					file.URL(), err)
-				return nil
-			}
-			if !rvr.Valid {
-				stats.remoteFailed++
-				errorCh <- csafErrs.ErrInvalidCsaf{Message: fmt.Sprintf("remote validation of CSAF document %s at URL %s failed", filename, file.URL())}
-				return fmt.Errorf("remote validation of %q failed", file.URL())
-			}
-			return nil
-		}
-
-		// Run all the validations.
-		valStatus := notValidatedValidationStatus
-		for _, check := range []func() error{
-			s256Check,
-			s512Check,
-			keysCheck,
-			schemaCheck,
-			filenameCheck,
-			remoteValidatorCheck,
-		} {
-			if err := check(); err != nil {
-				slog.Error("Validation check failed", "error", err)
-				valStatus.update(invalidValidationStatus)
-				if d.cfg.ValidationMode == ValidationStrict {
-					continue nextAdvisory
-				}
-			}
-		}
-		valStatus.update(validValidationStatus)
-
-		// Send to forwarder
-		if d.Forwarder != nil {
-			d.Forwarder.forward(
-				filename, data.String(),
-				valStatus,
-				string(s256Data),
-				string(s512Data))
-		}
-
-		if d.cfg.ForwardChannel {
-			// the bytes slice is modified by the next buffer modification, so we need to copy it
-			d.Csafs <- slices.Clone(data.Bytes())
-		}
-
-		if d.cfg.NoStore {
-			// Do not write locally.
-			if valStatus == validValidationStatus {
-				stats.succeeded++
-			}
-			continue
-		}
-
-		if err := expr.Extract(
-			`$.document.tracking.initial_release_date`, dateExtract, false, doc,
-		); err != nil {
-			slog.Warn("Cannot extract initial_release_date from advisory",
-				"url", file.URL())
-			initialReleaseDate = time.Now()
-		}
-		initialReleaseDate = initialReleaseDate.UTC()
-
-		// Advisories that failed validation are stored in a special folder.
-		var newDir string
-		if valStatus != validValidationStatus {
-			newDir = path.Join(d.cfg.Directory, failedValidationDir)
-		} else {
-			newDir = d.cfg.Directory
-		}
-
-		// Do we have a configured destination folder?
-		if d.cfg.Folder != "" {
-			newDir = path.Join(newDir, d.cfg.Folder)
-		} else {
-			newDir = path.Join(newDir, lower, strconv.Itoa(initialReleaseDate.Year()))
-		}
-
-		if newDir != lastDir {
-			if err := d.mkdirAll(newDir, 0755); err != nil {
-				errorCh <- err
-				continue
-			}
-			lastDir = newDir
-		}
-
-		// Write advisory to file
-		path := filepath.Join(lastDir, filename)
-
-		// Write data to disk.
-		for _, x := range []struct {
-			p string
-			d []byte
-		}{
-			{path, data.Bytes()},
-			{path + ".sha256", s256Data},
-			{path + ".sha512", s512Data},
-			{path + ".asc", signData},
-		} {
-			if x.d != nil {
-				if err := os.WriteFile(x.p, x.d, 0644); err != nil {
-					errorCh <- err
-					continue nextAdvisory
-				}
-			}
-		}
-
-		stats.succeeded++
-		slog.Info("Written advisory", "path", path)
 	}
 }
 

--- a/cmd/csaf_downloader/downloader_test.go
+++ b/cmd/csaf_downloader/downloader_test.go
@@ -24,12 +24,10 @@ import (
 func checkIfFileExists(path string, t *testing.T) bool {
 	if _, err := os.Stat(path); err == nil {
 		return true
-	} else if errors.Is(err, os.ErrNotExist) {
-		return false
-	} else {
+	} else if !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("Failed to check if file exists: %v", err)
-		return false
 	}
+	return false
 }
 
 func TestShaMarking(t *testing.T) {

--- a/cmd/csaf_downloader/forwarder.go
+++ b/cmd/csaf_downloader/forwarder.go
@@ -224,12 +224,12 @@ func (f *Forwarder) storeFailed(filename, doc, sha256, sha512 string) {
 
 // limitedString reads max bytes from reader and returns it as a string.
 // Longer strings are indicated by "..." as a suffix.
-func limitedString(r io.Reader, max int) (string, error) {
+func limitedString(r io.Reader, maxLength int) (string, error) {
 	var msg strings.Builder
-	if _, err := io.Copy(&msg, io.LimitReader(r, int64(max))); err != nil {
+	if _, err := io.Copy(&msg, io.LimitReader(r, int64(maxLength))); err != nil {
 		return "", err
 	}
-	if msg.Len() >= max {
+	if msg.Len() >= maxLength {
 		msg.WriteString("...")
 	}
 	return msg.String(), nil

--- a/cmd/csaf_provider/main.go
+++ b/cmd/csaf_provider/main.go
@@ -48,7 +48,7 @@ func main() {
 
 	cfg, err := loadConfig()
 	if err != nil {
-		cgi.Serve(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		cgi.Serve(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
 			http.Error(rw, "Something went wrong. Check server logs for more details",
 				http.StatusInternalServerError)
 		}))

--- a/docs/examples/aggregator.toml
+++ b/docs/examples/aggregator.toml
@@ -5,6 +5,7 @@ web = "/var/csaf_aggregator/html"
 domain = "https://localhost:9443"
 rate = 10.0
 insecure = true
+#verbose = false
 #openpgp_private_key =
 #openpgp_public_key =
 #interim_years =

--- a/docs/provider-setup.md
+++ b/docs/provider-setup.md
@@ -78,6 +78,9 @@ server {
 
         # directory listings
         autoindex on;
+
+        # allow others web applications to get the static information
+        add_header Access-Control-Allow-Origin "*";
     }
 
     # enable CGI
@@ -155,7 +158,7 @@ Again replacing `{clientCert.crt}` and `{clientKey.pem}` accordingly.
 
 
 To let nginx resolves the DNS record `csaf.data.security.domain.tld` to fulfill the [Requirement 10](https://docs.oasis-open.org/csaf/csaf/v2.0/cs01/csaf-v2.0-cs01.html#7110-requirement-10-dns-path) configure a new server block (virtual host) in a separated file under `/etc/nginx/available-sites/{DNSNAME}` like following:
-<!-- MARKDOWN-AUTO-DOCS:START (CODE:src=../docs/scripts/DNSConfigForItest.sh&lines=18-35) -->
+<!-- MARKDOWN-AUTO-DOCS:START (CODE:src=../docs/scripts/DNSConfigForItest.sh&lines=18-37) -->
 <!-- The below code snippet is automatically added from ../docs/scripts/DNSConfigForItest.sh -->
 ```sh
     server {

--- a/docs/scripts/DNSConfigForItest.sh
+++ b/docs/scripts/DNSConfigForItest.sh
@@ -28,6 +28,8 @@ echo "
 
         location = / {
                 try_files /.well-known/csaf/provider-metadata.json =404;
+                # allow others web applications to get the static information
+                add_header Access-Control-Allow-Origin "*";
         }
 
         access_log /var/log/nginx/dns-domain_access.log;

--- a/docs/scripts/setupProviderForITest.sh
+++ b/docs/scripts/setupProviderForITest.sh
@@ -61,6 +61,9 @@ echo "
 
         # directory listings
         autoindex on;
+
+        # allow others web applications to get the static information
+        add_header Access-Control-Allow-Origin "*";
 " > locationConfig.txt
 sudo sed -i "/^\s*location \/ {/r locationConfig.txt" $NGINX_CONFIG_PATH # Insert config inside location{}
 ./DNSConfigForItest.sh

--- a/internal/testutil/testutil.go
+++ b/internal/testutil/testutil.go
@@ -18,11 +18,12 @@ import (
 
 // ProviderParams configures the test provider.
 type ProviderParams struct {
-	URL          string
-	EnableSha256 bool
-	EnableSha512 bool
-	ForbidSha256 bool
-	ForbidSha512 bool
+	URL             string
+	EnableSha256    bool
+	EnableSha512    bool
+	ForbidSha256    bool
+	ForbidSha512    bool
+	JSONContentType string
 }
 
 // ProviderHandler returns a test provider handler with the specified configuration.
@@ -33,6 +34,11 @@ func ProviderHandler(params *ProviderParams, directoryProvider bool) http.Handle
 			path += "simple-directory-provider"
 		} else {
 			path += "simple-rolie-provider"
+		}
+
+		jsonContenType := "application/json"
+		if params.JSONContentType != "" {
+			jsonContenType = params.JSONContentType
 		}
 
 		path += r.URL.Path
@@ -50,7 +56,7 @@ func ProviderHandler(params *ProviderParams, directoryProvider bool) http.Handle
 		case strings.HasSuffix(path, ".html"):
 			w.Header().Add("Content-Type", "text/html")
 		case strings.HasSuffix(path, ".json"):
-			w.Header().Add("Content-Type", "application/json")
+			w.Header().Add("Content-Type", jsonContenType)
 		case (strings.HasSuffix(path, ".sha256")) && params.ForbidSha256:
 			w.WriteHeader(http.StatusForbidden)
 			return

--- a/pkg/options/options_test.go
+++ b/pkg/options/options_test.go
@@ -37,10 +37,10 @@ func TestParse(t *testing.T) {
 		},
 		Usage:      "[OPTIONS] domain...",
 		HasVersion: func(cfg *config) bool { return cfg.Version },
-		SetDefaults: func(cfg *config) {
+		SetDefaults: func(_ *config) {
 		},
 		// Re-establish default values if not set.
-		EnsureDefaults: func(cfg *config) {
+		EnsureDefaults: func(_ *config) {
 		},
 	}
 
@@ -157,7 +157,6 @@ func TestErrorCheck(t *testing.T) {
 		return
 	}
 	t.Fatalf("process ran with err %v, want exit status 1", err)
-
 }
 
 // TestSecondPassCommandlineParsing checks if the second pass
@@ -168,7 +167,7 @@ func TestSecondPassCommandlineParsing(t *testing.T) {
 
 	os.Args = []string{"cmd"}
 	p := Parser[config]{
-		ConfigLocation: func(cfg *config) string {
+		ConfigLocation: func(_ *config) string {
 			// This is a bit stupid.
 			os.Args = []string{"cmd", "--invalid"}
 			return "data/empty.toml"
@@ -188,7 +187,7 @@ func TestSecondPassCommandlineHelp(t *testing.T) {
 
 		os.Args = []string{"cmd"}
 		p := Parser[config]{
-			ConfigLocation: func(cfg *config) string {
+			ConfigLocation: func(_ *config) string {
 				// This is a bit stupid.
 				os.Args = []string{"cmd", "--help"}
 				return "data/empty.toml"

--- a/util/file_test.go
+++ b/util/file_test.go
@@ -155,7 +155,7 @@ func TestMakeUniqFile(t *testing.T) {
 
 func Test_mkUniq(t *testing.T) {
 	dir := t.TempDir()
-	name, err := mkUniq(dir+"/", func(name string) error {
+	name, err := mkUniq(dir+"/", func(_ string) error {
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
## What

Add upstream changes. No functional changes to the CSAF downloader. Diff is mainly due to the refactor of the csaf downloader to fix memory leaks (which was already fixed in our fork).

----

To make reading the diff easier a summary of the refactor:

`func (d *Downloader) downloadWorker` is still the same, but instead of a variable block in the beginning the vars are initialized via `newDownloadContext()` where the new struct `downloadContext` holds all those variables.

The rest of the loop after  `case <-ctx.Done():` was moved to `dc.downloadAdvisory`, a new method of this struct, which downloads a single advisory and is called every loop iteration.
As a result all `continue` or `continue nextAdvisory` are replaced by a `return nil` and all the vars from the variable block are now prefixed by `dc.` as they are part of the `downloadContext` rather than local variables.

The only functional change was to fix the memory/goroutine leak: 
- `defer resp.Body.Close()` was added after `client.Get(file.URL())` error check
- `io.TeeReader(resp.Body, hasher)` is no longer called in a lambda function (no longer needed, as we are already in a function which processes only a single advisory)


## Why

Keep our fork up to date.


