### PR TITLE
change: avoid log spam due to not provided sha sums

### DIFF
--- a/cmd/csaf_downloader/downloader.go
+++ b/cmd/csaf_downloader/downloader.go
@@ -530,7 +530,7 @@ func (dc *downloadContext) downloadAdvisory(
 			preferred: strings.EqualFold(string(dc.d.cfg.PreferredHash), string(algSha512)),
 		})
 	} else {
-		slog.Info("SHA512 not present")
+		slog.Debug("SHA512 not present")
 	}
 	if file.SHA256URL() != "" {
 		hashToFetch = append(hashToFetch, hashFetchInfo{
@@ -540,7 +540,7 @@ func (dc *downloadContext) downloadAdvisory(
 			preferred: strings.EqualFold(string(dc.d.cfg.PreferredHash), string(algSha256)),
 		})
 	} else {
-		slog.Info("SHA256 not present")
+		slog.Debug("SHA256 not present")
 	}
 	if file.IsDirectory() {
 		for i := range hashToFetch {


### PR DESCRIPTION
## What

Avoid log spam due to not provided sha sums.

A provider is not required to provide both sha256 and sha512 checksums. Therefor the log message regarding a not present sha sum is expected and can cause a lot of log messages. This is therefore more suitable on log channel `debug`.

## Why

Make the info channel well readable containing without noise.


