### PR TITLE
ci: update linting-action

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -13,4 +13,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
-      - uses: golangci/golangci-lint-action@v6
+      - uses: golangci/golangci-lint-action@1481404843c368bc19ca9406f87d6e0fc97bdcfd # v7.0.0


### PR DESCRIPTION
## What

update linting-action, also using commit hash instead of version

## Why

Use latest version and comply with DevOps guidelines.


