### PR TITLE
fix: add missing errors on missing signature or checksum

### DIFF
--- a/csaf/advisories.go
+++ b/csaf/advisories.go
@@ -407,9 +407,13 @@ func (afp *AdvisoryFileProcessor) processROLIE(
 			switch {
 			case sha256 == "" && sha512 == "":
 				slog.Error("No hash listed on ROLIE feed", "file", self)
+				err := errs.ErrCsafProviderIssue{Message: fmt.Sprintf("no hash listed on TLP:%s ROLIE feed (%s) for CSAF %s", label, feedURL.String(), self)}
+				feedErrs = append(feedErrs, err)
 				return
 			case sign == "":
 				slog.Error("No signature listed on ROLIE feed", "file", self)
+				err := errs.ErrCsafProviderIssue{Message: fmt.Sprintf("no signature listed on TLP:%s ROLIE feed (%s) for CSAF %s", label, feedURL.String(), self)}
+				feedErrs = append(feedErrs, err)
 				return
 			default:
 				file = PlainAdvisoryFile{self, sha256, sha512, sign}


### PR DESCRIPTION
## What

fix: add missing errors on missing signature or checksum

This is a newly integrated upstream feature, so we need our own error handling to those checks to get more than just a logged error as feedback.

*Note:* These error checks only apply to missing references in the ROLIE feed, this does not change the error handling for the retrieval and parsing of the signature and checksum files.

## Why

We want to benefit from the improved error handling and fail the download on ROLIE feeds which don't provide links to all required files as per CSAF specification.
