### PR TITLE
fix: flatten errors correctly for directory based CSAF providers

### DIFF
--- a/cmd/csaf_downloader/downloader.go
+++ b/cmd/csaf_downloader/downloader.go
@@ -492,7 +492,7 @@ func (dc *downloadContext) downloadAdvisory(
 		case resp.StatusCode == http.StatusUnauthorized:
 			errorCh <- csafErrs.ErrInvalidCredentials{Message: fmt.Sprintf("invalid credentials to retrieve CSAF document %s at URL %s: %s", filename, file.URL(), resp.Status)}
 		case resp.StatusCode == http.StatusForbidden:
-			// if we have access to the feed containing the document, we also must have access to itself, otherwise this inidates a problem with the provider
+			// if we have access to the feed containing the document, we also must have access to itself, otherwise this indicates a problem with the provider
 			errorCh <- csafErrs.ErrCsafProviderIssue{Message: fmt.Sprintf("access denied to CSAF document %s at URL %s: %s", filename, file.URL(), resp.Status)}
 		case resp.StatusCode == http.StatusNotFound:
 			errorCh <- csafErrs.ErrCsafProviderIssue{Message: fmt.Sprintf("could not find CSAF document %s listed in table of content at URL %s: %s ", filename, file.URL(), resp.Status)}

--- a/csaf/advisories.go
+++ b/csaf/advisories.go
@@ -230,7 +230,7 @@ func (afp *AdvisoryFileProcessor) loadChanges(
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		switch { // we don't expect 401 and 403, as diretory based feeds are supposed to be public, but just to be on the safe side
+		switch { // we don't expect 401 and 403, as directory based feeds are supposed to be public, but just to be on the safe side
 		case resp.StatusCode == http.StatusUnauthorized:
 			return nil, errs.ErrInvalidCredentials{Message: fmt.Sprintf("invalid credentials for accessing %s: %s", changesURL, resp.Status)}
 		case resp.StatusCode == http.StatusForbidden:

--- a/csaf/advisories.go
+++ b/csaf/advisories.go
@@ -343,8 +343,8 @@ func (afp *AdvisoryFileProcessor) processROLIE(
 			case res.StatusCode >= 500:
 				providerErr := errs.ErrCsafProviderIssue{Message: fmt.Sprintf("could not retrieve TLP:%s ROLIE feed at %s: %s", label, feedURL.String(), res.Status)}
 				feedErrs = append(feedErrs, fmt.Errorf("%w %w", providerErr, errs.ErrRetryable)) // mark error as retryable as failure for server side errors are often temporary
-			default:
-				feedErrs = append(feedErrs, errs.ErrCsafProviderIssue{Message: fmt.Sprintf("could not retrieve TLP:%s ROLIE feed at %s: %s", label, feedURL.String(), res.Status)})
+			default: // client error or fringe case
+				feedErrs = append(feedErrs, fmt.Errorf("could not retrieve TLP:%s ROLIE feed at %s: %s", label, feedURL.String(), res.Status))
 			}
 			continue
 		}

--- a/pkg/errs/errors.go
+++ b/pkg/errs/errors.go
@@ -47,14 +47,14 @@ func (e ErrInvalidCredentials) Error() string {
 
 var ErrRetryable = errors.New("(retryable error)")
 
-// CompositeErrRolieFeed holds an array of errors which encountered during processing rolie feeds
-type CompositeErrRolieFeed struct {
+// CompositeErrFeed holds an array of errors which encountered during processing rolie feeds
+type CompositeErrFeed struct {
 	Errs []error
 }
 
-func (e *CompositeErrRolieFeed) Error() string {
+func (e *CompositeErrFeed) Error() string {
 	if len(e.Errs) == 0 {
-		return "empty CompositeErrRolieFeed"
+		return "empty CompositeErrFeed"
 	}
 
 	messages := make([]string, 0, len(e.Errs))
@@ -64,7 +64,7 @@ func (e *CompositeErrRolieFeed) Error() string {
 	return strings.Join(messages, "\n")
 }
 
-func (e *CompositeErrRolieFeed) Unwrap() []error {
+func (e *CompositeErrFeed) Unwrap() []error {
 	return e.Errs
 }
 
@@ -89,10 +89,10 @@ func (e *CompositeErrCsafDownload) Unwrap() []error {
 	return e.Errs
 }
 
-// FlattenError flattens out all composite errors (note: discards the errors wrapped around [CompositeErrRolieFeed] or [CompositeErrCsafDownload])
-// The assumed structure is CompositeErrRolieFeed{Errs: []error{...,CompositeErrCsafDownload,...,CompositeErrCsafDownload,...}}.
+// FlattenError flattens out all composite errors (note: discards the errors wrapped around [CompositeErrFeed] or [CompositeErrCsafDownload])
+// The assumed structure is CompositeErrFeed{Errs: []error{...,CompositeErrCsafDownload,...,CompositeErrCsafDownload,...}}.
 func FlattenError(err error) (flattenedErrors []error) {
-	var rolieErrs *CompositeErrRolieFeed
+	var rolieErrs *CompositeErrFeed
 	if errors.As(err, &rolieErrs) {
 		for _, rolieErr := range rolieErrs.Unwrap() {
 			var csafDlErrs *CompositeErrCsafDownload

--- a/pkg/errs/errors_test.go
+++ b/pkg/errs/errors_test.go
@@ -26,21 +26,21 @@ func TestFlattenError(t *testing.T) {
 
 		compositeErrCsafDownload := &CompositeErrCsafDownload{Errs: csafDownloadErrsFlat}
 
-		singleRolieFeedErrs := []error{
-			errors.New("single error rolie feed 1"),
-			errors.New("single error rolie feed 2"),
+		singleFeedErrs := []error{
+			errors.New("single error feed 1"),
+			errors.New("single error feed 2"),
 		}
 
-		rolieFeedCompositeErr := CompositeErrRolieFeed{
+		feedCompositeErr := CompositeErrFeed{
 			Errs: append(
-				singleRolieFeedErrs,
-				fmt.Errorf("issues during downloader of rolie: %w", compositeErrCsafDownload),
+				singleFeedErrs,
+				fmt.Errorf("issues during download of feed: %w", compositeErrCsafDownload),
 				compositeErrCsafDownload,
 			),
 		}
-		wantFlattenedErrors := slices.Concat(singleRolieFeedErrs, csafDownloadErrsFlat, csafDownloadErrsFlat)
+		wantFlattenedErrors := slices.Concat(singleFeedErrs, csafDownloadErrsFlat, csafDownloadErrsFlat)
 
-		gotFlattenedErrors := FlattenError(fmt.Errorf("wrap rolie feed composite err: %w", &rolieFeedCompositeErr))
+		gotFlattenedErrors := FlattenError(fmt.Errorf("wrap feed composite err: %w", &feedCompositeErr))
 
 		assert.ElementsMatch(t, wantFlattenedErrors, gotFlattenedErrors)
 	})


### PR DESCRIPTION
## What

Flatten errors correctly for directory based CSAF poviders. 

Aligned error structure for directory based CSAF poviders. Previously `errors.FlattenError` did only support ROLIE feed based csaf providers as this feature was only targeted at restricted CSAF sources which are always ROLIE feed based.

This was not clearly enough stated in the function doc comment which can easily lead to incorrect results when using this function with directory based CSAF providers. In this case `errors.FlattenError` was a no-op just returning the original error. 

## Why

We want to support fine grained error handling also for directory based CSAF providers and avoid traps for the caller of `errors.FlattenError`. The caller usually won't know if the CSAF provider is ROLIE or directory based, unless it is a restricted CSAF provider which rules out the latter case. Thus this would make it hard to rely on the output.

