### PR TITLE
add: support setting proxy via custom env vars

### DIFF
--- a/cmd/csaf_downloader/downloader.go
+++ b/cmd/csaf_downloader/downloader.go
@@ -921,20 +921,18 @@ func (d *Downloader) RunEnumerate(domains []string) error {
 // proxyFromEnvironment sets the proxy from the environment variables.
 // The proxy is set as documented in [http.ProxyFromEnvironment],
 // However the http(s) proxy can be also set via env vars `CSAF_DL_HTTP_PROXY`
-// and `CSAF_DL_HTTPS_PROXY`. They will take precedence over `http_proxy`
-// and `https_proxy` and also their upper case versions.
-// Setting these custom env vars to an empty string will explicitly disable
-// the proxy for the CSAF downloader.
+// and `CSAF_DL_HTTPS_PROXY`. If set to a non empty string, they will take precedence
+// over `http_proxy` and `https_proxy` and also their upper case versions.
 // The purpose is to allow setting the proxy specifically for the CSAF downloader.
 func proxyFromEnvironment(req *http.Request) (*url.URL, error) {
 	cfg := httpproxy.FromEnvironment()
 
-	csafHTTPProxy, set := os.LookupEnv("CSAF_DL_HTTP_PROXY")
-	if set {
+	csafHTTPProxy := os.Getenv("CSAF_DL_HTTP_PROXY")
+	if csafHTTPProxy != "" {
 		cfg.HTTPProxy = csafHTTPProxy
 	}
-	csafHTTPSProxy, set := os.LookupEnv("CSAF_DL_HTTPS_PROXY")
-	if set {
+	csafHTTPSProxy := os.Getenv("CSAF_DL_HTTPS_PROXY")
+	if csafHTTPSProxy != "" {
 		cfg.HTTPSProxy = csafHTTPSProxy
 	}
 

--- a/cmd/csaf_downloader/downloader.go
+++ b/cmd/csaf_downloader/downloader.go
@@ -31,6 +31,7 @@ import (
 	"time"
 
 	"github.com/ProtonMail/gopenpgp/v2/crypto"
+	"golang.org/x/net/http/httpproxy"
 	"golang.org/x/time/rate"
 
 	"github.com/gocsaf/csaf/v3/csaf"
@@ -132,7 +133,7 @@ func (d *Downloader) httpClient() util.Client {
 
 	hClient.Transport = &http.Transport{
 		TLSClientConfig: &tlsConfig,
-		Proxy:           http.ProxyFromEnvironment,
+		Proxy:           proxyFromEnvironment,
 	}
 
 	client := util.Client(&hClient)
@@ -915,4 +916,27 @@ func (d *Downloader) RunEnumerate(domains []string) error {
 		}
 	}
 	return nil
+}
+
+// proxyFromEnvironment sets the proxy from the environment variables.
+// The proxy is set as documented in [http.ProxyFromEnvironment],
+// However the http(s) proxy can be also set via env vars `CSAF_DL_HTTP_PROXY`
+// and `CSAF_DL_HTTPS_PROXY`. They will take precedence over `http_proxy`
+// and `https_proxy` and also their upper case versions.
+// Setting these custom env vars to an empty string will explicitly disable
+// the proxy for the CSAF downloader.
+// The purpose is to allow setting the proxy specifically for the CSAF downloader.
+func proxyFromEnvironment(req *http.Request) (*url.URL, error) {
+	cfg := httpproxy.FromEnvironment()
+
+	csafHTTPProxy, set := os.LookupEnv("CSAF_DL_HTTP_PROXY")
+	if set {
+		cfg.HTTPProxy = csafHTTPProxy
+	}
+	csafHTTPSProxy, set := os.LookupEnv("CSAF_DL_HTTPS_PROXY")
+	if set {
+		cfg.HTTPSProxy = csafHTTPSProxy
+	}
+
+	return cfg.ProxyFunc()(req.URL)
 }

--- a/cmd/csaf_downloader/downloader_test.go
+++ b/cmd/csaf_downloader/downloader_test.go
@@ -174,7 +174,7 @@ func TestProxyFromEnvironment(t *testing.T) {
 		wantHTTPProxy    string
 		wantHTTPSProxy   string
 	}{
-		"custom env vars take precedence": {
+		"custom http proxy env vars take precedence": {
 			httpProxy:        "http://example.com:8080",
 			httpsProxy:       "https://example.com:8443",
 			csafDLHTTPProxy:  toPtr("http://custom.com:8080"),
@@ -182,13 +182,13 @@ func TestProxyFromEnvironment(t *testing.T) {
 			wantHTTPProxy:    "custom.com:8080",
 			wantHTTPSProxy:   "custom.com:8443",
 		},
-		"empty custom env vars disables proxy": {
+		"common http proxy env vars are still applied if custom env vars are set to empty string": {
 			httpProxy:        "http://example.com:8080",
 			httpsProxy:       "https://example.com:8443",
 			csafDLHTTPProxy:  toPtr(""),
 			csafDLHTTPSProxy: toPtr(""),
-			wantHTTPProxy:    "",
-			wantHTTPSProxy:   "",
+			wantHTTPProxy:    "example.com:8080",
+			wantHTTPSProxy:   "example.com:8443",
 		},
 		"common http proxy env vars are still applied if custom env vars are unset": {
 			httpProxy:        "http://example.com:8080",

--- a/cmd/csaf_downloader/downloader_test.go
+++ b/cmd/csaf_downloader/downloader_test.go
@@ -215,7 +215,7 @@ func TestProxyFromEnvironment(t *testing.T) {
 				req := httptest.NewRequest("GET", targetURL, nil)
 				proxyURL, err := proxyFromEnvironment(req)
 				if proxyURL == nil {
-					proxyURL = &url.URL{} // it us cumbersome to check for nil later
+					proxyURL = &url.URL{} // it is cumbersome to check for nil later
 				}
 				return *proxyURL, err
 			}

--- a/cmd/csaf_downloader/downloader_test.go
+++ b/cmd/csaf_downloader/downloader_test.go
@@ -13,12 +13,14 @@ import (
 	"errors"
 	"log/slog"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"testing"
 
 	"github.com/gocsaf/csaf/v3/internal/testutil"
 	"github.com/gocsaf/csaf/v3/pkg/options"
 	"github.com/gocsaf/csaf/v3/util"
+	"github.com/stretchr/testify/assert"
 )
 
 func checkIfFileExists(path string, t *testing.T) bool {
@@ -155,6 +157,77 @@ func TestShaMarking(t *testing.T) {
 			if sha512Exists != test.wantSha512 {
 				t.Errorf("%v: expected sha512 hash present to be %v, got: %v", test.name, test.wantSha512, sha512Exists)
 			}
+		})
+	}
+}
+
+func toPtr[T any](v T) *T {
+	return &v
+}
+
+func TestProxyFromEnvironment(t *testing.T) {
+	tests := map[string]struct {
+		httpProxy        string
+		httpsProxy       string
+		csafDLHTTPProxy  *string
+		csafDLHTTPSProxy *string
+		wantHTTPProxy    string
+		wantHTTPSProxy   string
+	}{
+		"custom env vars take precedence": {
+			httpProxy:        "http://example.com:8080",
+			httpsProxy:       "https://example.com:8443",
+			csafDLHTTPProxy:  toPtr("http://custom.com:8080"),
+			csafDLHTTPSProxy: toPtr("https://custom.com:8443"),
+			wantHTTPProxy:    "custom.com:8080",
+			wantHTTPSProxy:   "custom.com:8443",
+		},
+		"empty custom env vars disables proxy": {
+			httpProxy:        "http://example.com:8080",
+			httpsProxy:       "https://example.com:8443",
+			csafDLHTTPProxy:  toPtr(""),
+			csafDLHTTPSProxy: toPtr(""),
+			wantHTTPProxy:    "",
+			wantHTTPSProxy:   "",
+		},
+		"common http proxy env vars are still applied if custom env vars are unset": {
+			httpProxy:        "http://example.com:8080",
+			httpsProxy:       "https://example.com:8443",
+			csafDLHTTPProxy:  nil,
+			csafDLHTTPSProxy: nil,
+			wantHTTPProxy:    "example.com:8080",
+			wantHTTPSProxy:   "example.com:8443",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Setenv("http_proxy", tt.httpProxy)
+			t.Setenv("https_proxy", tt.httpsProxy)
+			if tt.csafDLHTTPProxy != nil {
+				t.Setenv("CSAF_DL_HTTP_PROXY", *tt.csafDLHTTPProxy)
+			}
+			if tt.csafDLHTTPSProxy != nil {
+				t.Setenv("CSAF_DL_HTTPS_PROXY", *tt.csafDLHTTPSProxy)
+			}
+
+			getProxyURL := func(targetURL string) (url.URL, error) {
+				req := httptest.NewRequest("GET", targetURL, nil)
+				proxyURL, err := proxyFromEnvironment(req)
+				if proxyURL == nil {
+					proxyURL = &url.URL{} // it us cumbersome to check for nil later
+				}
+				return *proxyURL, err
+			}
+
+			proxyURL, err := getProxyURL("http://target.com")
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantHTTPProxy, proxyURL.Host, "http proxy mismatch")
+
+			// same checks for https
+			proxyURL, err = getProxyURL("https://target.com")
+			assert.NoError(t, err)
+			assert.Equal(t, tt.wantHTTPSProxy, proxyURL.Host, "https proxy mismatch")
 		})
 	}
 }

--- a/docs/csaf_downloader.md
+++ b/docs/csaf_downloader.md
@@ -167,3 +167,8 @@ unattented. In this situation the processing environment should be secured
 properly instead.
 
 [^1]: Accepted syntax is described [here](https://github.com/google/re2/wiki/Syntax).
+
+#### Using Proxy
+
+The CSAF Downloader can be configured to use a proxy. You need to define environment variables as described in [httpproxy.ProxyFromEnvironment](https://pkg.go.dev/golang.org/x/net/http/httpproxy#FromEnvironment). Additionally you can set the proxy explicitly only for the CSAF Downloader via the environment variables `CSAF_DL_HTTP_PROXY`
+and `CSAF_DL_HTTPS_PROXY`. They will take precedence over `http_proxy` and `https_proxy` and also their upper case versions. Setting these custom env vars to an empty string will explicitly disable the proxy for the CSAF downloader.

--- a/docs/csaf_downloader.md
+++ b/docs/csaf_downloader.md
@@ -171,4 +171,4 @@ properly instead.
 #### Using Proxy
 
 The CSAF Downloader can be configured to use a proxy. You need to define environment variables as described in [httpproxy.ProxyFromEnvironment](https://pkg.go.dev/golang.org/x/net/http/httpproxy#FromEnvironment). Additionally you can set the proxy explicitly only for the CSAF Downloader via the environment variables `CSAF_DL_HTTP_PROXY`
-and `CSAF_DL_HTTPS_PROXY`. They will take precedence over `http_proxy` and `https_proxy` and also their upper case versions. Setting these custom env vars to an empty string will explicitly disable the proxy for the CSAF downloader.
+and `CSAF_DL_HTTPS_PROXY`. If set to a non empty string, they will take precedence over `http_proxy` and `https_proxy` and also their upper case versions.


### PR DESCRIPTION
## What

Support setting proxy via custom env vars  `CSAF_DL_HTTP_PROXY` and `CSAF_DL_HTTPS_PROXY`.

If set to a non empty string, they will take precedence over `http_proxy` and `https_proxy` and also their upper case versions.

## Why

There are scenarios where we want to apply a proxy only for the CSAF Downloader. Setting `http_proxy` and `https_proxy` usually affects several other tools running in the same environment. So having the option to use the custom env vars allows us to avoid that.

## References

VTI-619

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


