### PR TITLE
Merge upstream

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,15 +12,15 @@ SHELL = /bin/bash
 BUILD = go build
 MKDIR = mkdir -p
 
-.PHONY: build build_linux build_win build_mac_amd64 build_mac_arm64 tag_checked_out mostlyclean
+.PHONY: build build_linux build_linux_arm64 build_win build_win_arm64 build_mac_amd64 build_mac_arm64 tag_checked_out mostlyclean
 
 all:
-	@echo choose a target from: build build_linux build_win build_mac_amd64 build_mac_arm64 mostlyclean
+	@echo choose a target from: build build_linux build_linux_arm64 build_win build_win_arm64 build_mac_amd64 build_mac_arm64 mostlyclean
 	@echo prepend \`make BUILDTAG=1\` to checkout the highest git tag before building
 	@echo or set BUILDTAG to a specific tag
 
 # Build all binaries
-build: build_linux build_win build_mac_amd64 build_mac_arm64
+build: build_linux build_linux_arm64 build_win build_win_arm64 build_mac_amd64 build_mac_arm64
 
 # if BUILDTAG == 1 set it to the highest git tag
 ifeq ($(strip $(BUILDTAG)),1)
@@ -29,7 +29,7 @@ endif
 
 ifdef BUILDTAG
 # add the git tag checkout to the requirements of our build targets
-build_linux build_win build_mac_amd64 build_mac_arm64: tag_checked_out
+build_linux build_linux_arm64 build_win build_win_arm64 build_mac_amd64 build_mac_arm64: tag_checked_out
 endif
 
 tag_checked_out:
@@ -47,7 +47,7 @@ tag_checked_out:
 #   In this case we might in some situations see an error like
 #   `/bin/bash: line 1: 2b55bbb: value too great for base (error token is "2b55bbb")`
 #   which can be ignored.
-GITDESC := $(shell git describe --tags --always 2>/dev/null || true)
+GITDESC := $(shell git describe --tags --always --dirty=-modified 2>/dev/null || true)
 CURRENT_FOLDER_NAME := $(notdir $(CURDIR))
 ifeq ($(strip $(GITDESC)),)
 SEMVER := $(CURRENT_FOLDER_NAME)
@@ -69,31 +69,49 @@ LDFLAGS = -ldflags "-X github.com/gocsaf/csaf/v3/util.SemVersion=$(SEMVER)"
 # Build binaries and place them under bin-$(GOOS)-$(GOARCH)
 # Using 'Target-specific Variable Values' to specify the build target system
 
-GOARCH = amd64
-build_linux: GOOS = linux
-build_win: GOOS = windows
-build_mac_amd64: GOOS = darwin
+build_linux: GOOS=linux
+build_linux: GOARCH=amd64
 
-build_mac_arm64: GOARCH = arm64
-build_mac_arm64: GOOS = darwin
+build_win: GOOS=windows
+build_win: GOARCH=amd64
 
-build_linux build_win build_mac_amd64 build_mac_arm64:
+build_mac_amd64: GOOS=darwin
+build_mac_amd64: GOARCH=amd64
+
+build_mac_arm64: GOOS=darwin
+build_mac_arm64: GOARCH=arm64
+
+build_linux_arm64: GOOS=linux
+build_linux_arm64: GOARCH=arm64
+
+build_win_arm64: GOOS=windows
+build_win_arm64: GOARCH=arm64
+
+build_linux build_linux_arm64 build_win build_win_arm64 build_mac_amd64 build_mac_arm64:
 	$(eval BINDIR = bin-$(GOOS)-$(GOARCH)/ )
 	$(MKDIR) $(BINDIR)
 	env GOARCH=$(GOARCH) GOOS=$(GOOS) $(BUILD) -o $(BINDIR) $(LDFLAGS) -v ./cmd/...
 
 
 DISTDIR := csaf-$(SEMVER)
-dist: build_linux build_win build_mac_amd64 build_mac_arm64
+dist: build_linux build_linux_arm64 build_win build_win_arm64 build_mac_amd64 build_mac_arm64
 	mkdir -p dist
 	mkdir -p dist/$(DISTDIR)-windows-amd64/bin-windows-amd64
+	mkdir -p dist/$(DISTDIR)-windows-arm64/bin-windows-arm64
 	cp README.md dist/$(DISTDIR)-windows-amd64
+	cp README.md dist/$(DISTDIR)-windows-arm64
 	cp bin-windows-amd64/csaf_uploader.exe bin-windows-amd64/csaf_validator.exe \
 	  bin-windows-amd64/csaf_checker.exe bin-windows-amd64/csaf_downloader.exe \
 	  dist/$(DISTDIR)-windows-amd64/bin-windows-amd64/
+	cp bin-windows-arm64/csaf_uploader.exe bin-windows-arm64/csaf_validator.exe \
+	  bin-windows-arm64/csaf_checker.exe bin-windows-arm64/csaf_downloader.exe \
+	  dist/$(DISTDIR)-windows-arm64/bin-windows-arm64/
 	mkdir -p dist/$(DISTDIR)-windows-amd64/docs
+	mkdir -p dist/$(DISTDIR)-windows-arm64/docs
 	cp docs/csaf_uploader.md docs/csaf_validator.md docs/csaf_checker.md \
 	  docs/csaf_downloader.md dist/$(DISTDIR)-windows-amd64/docs
+	cp docs/csaf_uploader.md docs/csaf_validator.md docs/csaf_checker.md \
+	  docs/csaf_downloader.md dist/$(DISTDIR)-windows-arm64/docs
 	mkdir -p dist/$(DISTDIR)-macos/bin-darwin-amd64 \
 		     dist/$(DISTDIR)-macos/bin-darwin-arm64 \
 			 dist/$(DISTDIR)-macos/docs
@@ -103,9 +121,20 @@ dist: build_linux build_win build_mac_amd64 build_mac_arm64
 		cp docs/$${f}.md dist/$(DISTDIR)-macos/docs ; \
 	done
 	mkdir dist/$(DISTDIR)-gnulinux-amd64
-	cp -r README.md docs bin-linux-amd64 dist/$(DISTDIR)-gnulinux-amd64
+	mkdir dist/$(DISTDIR)-gnulinux-arm64
+	cp -r README.md bin-linux-amd64 dist/$(DISTDIR)-gnulinux-amd64
+	cp -r README.md bin-linux-arm64 dist/$(DISTDIR)-gnulinux-arm64
+	# adjust which docs to copy
+	mkdir -p dist/tmp_docs
+	cp -r docs/examples dist/tmp_docs
+	cp docs/*.md dist/tmp_docs
+	cp -r dist/tmp_docs dist/$(DISTDIR)-gnulinux-amd64/docs
+	cp -r dist/tmp_docs dist/$(DISTDIR)-gnulinux-arm64/docs
+	rm -rf dist/tmp_docs
 	cd dist/ ; zip -r $(DISTDIR)-windows-amd64.zip $(DISTDIR)-windows-amd64/
+	cd dist/ ; zip -r $(DISTDIR)-windows-arm64.zip $(DISTDIR)-windows-arm64/
 	cd dist/ ; tar -cvmlzf $(DISTDIR)-gnulinux-amd64.tar.gz $(DISTDIR)-gnulinux-amd64/
+	cd dist/ ; tar -cvmlzf $(DISTDIR)-gnulinux-arm64.tar.gz $(DISTDIR)-gnulinux-arm64/
 	cd dist/ ; tar -cvmlzf $(DISTDIR)-macos.tar.gz $(DISTDIR)-macos
 
 # Remove bin-*-* and dist directories

--- a/README.md
+++ b/README.md
@@ -9,14 +9,6 @@
 -->
 
 
-> [!IMPORTANT]
-> To avoid future breakage, if you still use `csaf-poc`:
-> 1. Adjust your HTML links.
-> 2. Adjust your go module paths, see [#579](https://github.com/gocsaf/csaf/issues/579#issuecomment-2497244379).
->
-> (This repository was moved here on 2024-10-28. The old one is deprecated
-> and redirection will be switched off a few months later.)
-
 
 # csaf
 
@@ -49,13 +41,20 @@ is a tool for testing a CSAF Trusted Provider according to [Section 7 of the CSA
 ### [csaf_aggregator](docs/csaf_aggregator.md)
 is a CSAF Aggregator, to list or mirror providers.
 
-## Other stuff
+
+## Use as go library
+
+The modules of this repository can be used as library by other Go applications. [ISDuBA](https://github.com/ISDuBA/ISDuBA) does so, for example.
+But there is only limited support and thus it is _not officially supported_.
+There are plans to change this without a concrete schedule within a future major release, e.g. see [#367](https://github.com/gocsaf/csaf/issues/367).
+
+Initially envisioned as a toolbox, it was not constructed as a library,
+and to name one issue, exposes too many functions.
+This leads to problems like [#634](https://github.com/gocsaf/csaf/issues/634), where we have to accept that with 3.2.0 there was an unintended API change.
 
 ### [examples](./examples/README.md)
-are small examples of how to use `github.com/gocsaf/csaf`
-as an API. Currently this is a work in progress, as usage of this repository
-as a library to access is _not officially supported_, e.g.
-see https://github.com/gocsaf/csaf/issues/367 .
+are small examples of how to use `github.com/gocsaf/csaf` as an API. Currently this is a work in progress.
+
 
 ## Setup
 Binaries for the server side are only available and tested
@@ -107,6 +106,14 @@ Binaries will be placed in directories named like `bin-linux-amd64/` and `bin-wi
 
 For further details of the development process consult our [development page](./docs/Development.md).
 
+## Previous repo URLs
+
+> [!NOTE]
+> To avoid future breakage, if you have `csaf-poc` in some of your URLs:
+> 1. Adjust your HTML links.
+> 2. Adjust your go module paths, see [#579](https://github.com/gocsaf/csaf/issues/579#issuecomment-2497244379).
+>
+> (This repository was moved here from https://github.com/csaf-poc/csaf_distribution on 2024-10-28. The old one is deprecated and redirection will be switched off sometime in 2025.)
 
 ## License
 

--- a/cmd/csaf_aggregator/interim.go
+++ b/cmd/csaf_aggregator/interim.go
@@ -13,7 +13,6 @@ import (
 	"crypto/sha256"
 	"crypto/sha512"
 	"encoding/csv"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -25,6 +24,7 @@ import (
 	"time"
 
 	"github.com/gocsaf/csaf/v3/csaf"
+	"github.com/gocsaf/csaf/v3/internal/misc"
 	"github.com/gocsaf/csaf/v3/util"
 )
 
@@ -81,7 +81,7 @@ func (w *worker) checkInterims(
 		if err := func() error {
 			defer res.Body.Close()
 			tee := io.TeeReader(res.Body, hasher)
-			return json.NewDecoder(tee).Decode(&doc)
+			return misc.StrictJSONParse(tee, &doc)
 		}(); err != nil {
 			return nil, err
 		}

--- a/cmd/csaf_checker/links.go
+++ b/cmd/csaf_checker/links.go
@@ -13,6 +13,8 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/gocsaf/csaf/v3/internal/misc"
+
 	"github.com/PuerkitoBio/goquery"
 
 	"github.com/gocsaf/csaf/v3/util"
@@ -93,7 +95,12 @@ func (pgs pages) listed(
 				return err
 			}
 			// Links may be relative
-			abs := baseURL.ResolveReference(u).String()
+			var abs string
+			if u.IsAbs() {
+				abs = u.String()
+			} else {
+				abs = misc.JoinURL(baseURL, u).String()
+			}
 			content.links.Add(abs)
 			return nil
 		})

--- a/cmd/csaf_checker/roliecheck.go
+++ b/cmd/csaf_checker/roliecheck.go
@@ -216,11 +216,6 @@ func defaults[T any](p *T, def T) T {
 // processROLIEFeeds goes through all ROLIE feeds and checks their
 // integrity and completeness.
 func (p *processor) processROLIEFeeds(feeds [][]csaf.Feed) error {
-
-	base, err := url.Parse(p.pmdURL)
-	if err != nil {
-		return err
-	}
 	p.badROLIEFeed.use()
 
 	advisories := map[*csaf.Feed][]csaf.AdvisoryFile{}
@@ -232,12 +227,11 @@ func (p *processor) processROLIEFeeds(feeds [][]csaf.Feed) error {
 			if feed.URL == nil {
 				continue
 			}
-			up, err := url.Parse(string(*feed.URL))
+			feedBase, err := url.Parse(string(*feed.URL))
 			if err != nil {
 				p.badProviderMetadata.error("Invalid URL %s in feed: %v.", *feed.URL, err)
 				continue
 			}
-			feedBase := base.ResolveReference(up)
 			feedURL := feedBase.String()
 			p.checkTLS(feedURL)
 
@@ -264,13 +258,12 @@ func (p *processor) processROLIEFeeds(feeds [][]csaf.Feed) error {
 				continue
 			}
 
-			up, err := url.Parse(string(*feed.URL))
+			feedURL, err := url.Parse(string(*feed.URL))
 			if err != nil {
 				p.badProviderMetadata.error("Invalid URL %s in feed: %v.", *feed.URL, err)
 				continue
 			}
 
-			feedURL := base.ResolveReference(up)
 			feedBase, err := util.BaseURL(feedURL)
 			if err != nil {
 				p.badProviderMetadata.error("Bad base path: %v", err)
@@ -290,7 +283,7 @@ func (p *processor) processROLIEFeeds(feeds [][]csaf.Feed) error {
 			// TODO: Issue a warning if we want check AMBER+ without an
 			// authorizing client.
 
-			if err := p.integrity(files, feedBase, rolieMask, p.badProviderMetadata.add); err != nil {
+			if err := p.integrity(files, rolieMask, p.badProviderMetadata.add); err != nil {
 				if err != errContinue {
 					return err
 				}
@@ -319,13 +312,12 @@ func (p *processor) processROLIEFeeds(feeds [][]csaf.Feed) error {
 				continue
 			}
 
-			up, err := url.Parse(string(*feed.URL))
+			feedBase, err := url.Parse(string(*feed.URL))
 			if err != nil {
 				p.badProviderMetadata.error("Invalid URL %s in feed: %v.", *feed.URL, err)
 				continue
 			}
 
-			feedBase := base.ResolveReference(up)
 			makeAbs := makeAbsolute(feedBase)
 			label := defaults(feed.TLPLabel, csaf.TLPLabelUnlabeled)
 

--- a/cmd/csaf_provider/config.go
+++ b/cmd/csaf_provider/config.go
@@ -11,6 +11,7 @@ package main
 import (
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"strings"
 
@@ -261,6 +262,14 @@ func loadConfig() (*config, error) {
 
 	if cfg.CanonicalURLPrefix == "" {
 		cfg.CanonicalURLPrefix = "https://" + os.Getenv("SERVER_NAME")
+	}
+	// Check if canonical url prefix is invalid
+	parsedURL, err := url.ParseRequestURI(cfg.CanonicalURLPrefix)
+	if err != nil {
+		return nil, err
+	}
+	if parsedURL.Scheme != "https" && parsedURL.Scheme != "http" {
+		return nil, fmt.Errorf("invalid canonical URL: %q", cfg.CanonicalURLPrefix)
 	}
 
 	if cfg.TLPs == nil {

--- a/cmd/csaf_validator/main.go
+++ b/cmd/csaf_validator/main.go
@@ -10,7 +10,6 @@
 package main
 
 import (
-	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -19,6 +18,7 @@ import (
 	"github.com/jessevdk/go-flags"
 
 	"github.com/gocsaf/csaf/v3/csaf"
+	"github.com/gocsaf/csaf/v3/internal/misc"
 	"github.com/gocsaf/csaf/v3/util"
 )
 
@@ -301,7 +301,7 @@ func loadJSONFromFile(fname string) (any, error) {
 	}
 	defer f.Close()
 	var doc any
-	if err = json.NewDecoder(f).Decode(&doc); err != nil {
+	if err = misc.StrictJSONParse(f, &doc); err != nil {
 		return nil, err
 	}
 	return doc, err

--- a/csaf/advisories.go
+++ b/csaf/advisories.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gocsaf/csaf/v3/internal/misc"
 	"github.com/gocsaf/csaf/v3/pkg/errs"
 	"github.com/gocsaf/csaf/v3/util"
 )
@@ -96,7 +97,7 @@ type AdvisoryFileProcessor struct {
 	client    util.Client
 	expr      *util.PathEval
 	doc       any
-	base      *url.URL
+	pmdURL    *url.URL
 }
 
 // NewAdvisoryFileProcessor constructs a filename extractor
@@ -105,13 +106,13 @@ func NewAdvisoryFileProcessor(
 	client util.Client,
 	expr *util.PathEval,
 	doc any,
-	base *url.URL,
+	pmdURL *url.URL,
 ) *AdvisoryFileProcessor {
 	return &AdvisoryFileProcessor{
 		client: client,
 		expr:   expr,
 		doc:    doc,
-		base:   base,
+		pmdURL: pmdURL,
 	}
 }
 
@@ -180,7 +181,7 @@ func (afp *AdvisoryFileProcessor) Process(
 
 		// Not found -> fall back to PMD url
 		if empty(dirURLs) {
-			baseURL, err := util.BaseURL(afp.base)
+			baseURL, err := util.BaseURL(afp.pmdURL)
 			if err != nil {
 				return err
 			}
@@ -278,8 +279,13 @@ func (afp *AdvisoryFileProcessor) loadChanges(
 			return nil, errs.ErrCsafProviderIssue{Message: fmt.Sprintf("could not read url from changes.csv: %v", err)}
 		}
 
+		pathURL, err := url.Parse(path)
+		if err != nil {
+			return nil, err
+		}
+
 		files = append(files,
-			DirectoryAdvisoryFile{Path: base.JoinPath(path).String()})
+			DirectoryAdvisoryFile{Path: misc.JoinURL(base, pathURL).String()})
 	}
 	return files, nil
 }
@@ -302,25 +308,18 @@ func (afp *AdvisoryFileProcessor) processROLIE(
 			label = "unknown"
 		}
 
-		up, err := url.Parse(string(*feed.URL))
+		feedURL, err := url.Parse(string(*feed.URL))
 		if err != nil {
 			slog.Error("Invalid URL in feed", "feed", *feed.URL, "err", err)
 			feedErrs = append(feedErrs, errs.ErrCsafProviderIssue{Message: fmt.Sprintf("invalid TLP:%s feed URL %s: %v", label, *feed.URL, err)})
 			continue
 		}
-		feedURL := afp.base.ResolveReference(up)
 		slog.Info("Got feed URL", "feed", feedURL)
 
 		fb, err := util.BaseURL(feedURL)
 		if err != nil {
 			slog.Error("Invalid feed base URL", "url", fb, "err", err)
 			feedErrs = append(feedErrs, errs.ErrCsafProviderIssue{Message: fmt.Sprintf("invalid TLP:%s feed base URL %s: %v", label, fb, err)})
-			continue
-		}
-		feedBaseURL, err := url.Parse(fb)
-		if err != nil {
-			slog.Error("Cannot parse feed base URL", "url", fb, "err", err)
-			feedErrs = append(feedErrs, errs.ErrCsafProviderIssue{Message: fmt.Sprintf("cannot parse TLP:%s feed base URL %s: %v", label, fb, err)})
 			continue
 		}
 
@@ -369,7 +368,7 @@ func (afp *AdvisoryFileProcessor) processROLIE(
 				slog.Error("Invalid URL", "url", u, "err", err)
 				return "", errs.ErrCsafProviderIssue{Message: fmt.Sprintf("invalid url in TLP:%s ROLIE feed at %s to file %s: %v", label, feedURL.String(), u, err)}
 			}
-			return feedBaseURL.ResolveReference(p).String(), nil
+			return p.String(), nil
 		}
 
 		rfeed.Entries(func(entry *Entry) {

--- a/csaf/advisory.go
+++ b/csaf/advisory.go
@@ -14,6 +14,8 @@ import (
 	"fmt"
 	"io"
 	"os"
+
+	"github.com/gocsaf/csaf/v3/internal/misc"
 )
 
 // Acknowledgement reflects the 'acknowledgement' object in the list of acknowledgements.
@@ -383,7 +385,6 @@ type Relationship struct {
 	FullProductName           *FullProductName      `json:"full_product_name"`            // required
 	ProductReference          *ProductID            `json:"product_reference"`            // required
 	RelatesToProductReference *ProductID            `json:"relates_to_product_reference"` // required
-
 }
 
 // Relationships is a list of Relationship.
@@ -1391,7 +1392,7 @@ func LoadAdvisory(fname string) (*Advisory, error) {
 	}
 	defer f.Close()
 	var advisory Advisory
-	if err := json.NewDecoder(f).Decode(&advisory); err != nil {
+	if err := misc.StrictJSONParse(f, &advisory); err != nil {
 		return nil, err
 	}
 	if err := advisory.Validate(); err != nil {

--- a/csaf/advisory_test.go
+++ b/csaf/advisory_test.go
@@ -1,0 +1,45 @@
+package csaf
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadAdvisory(t *testing.T) {
+	type args struct {
+		jsonDir string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+	}{{
+		name:    "Valid documents",
+		args:    args{jsonDir: "csaf-documents/valid"},
+		wantErr: false,
+	},
+		{
+			name:    "Garbage trailing data",
+			args:    args{jsonDir: "csaf-documents/trailing-garbage-data"},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := filepath.Walk("../testdata/"+tt.args.jsonDir, func(path string, info os.FileInfo, err error) error {
+				if err != nil {
+					return err
+				}
+				if info.Mode().IsRegular() && filepath.Ext(info.Name()) == ".json" {
+					if _, err := LoadAdvisory(path); (err != nil) != tt.wantErr {
+						t.Errorf("LoadAdvisory() error = %v, wantErr %v", err, tt.wantErr)
+					}
+				}
+				return nil
+			}); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}

--- a/csaf/doc.go
+++ b/csaf/doc.go
@@ -6,7 +6,11 @@
 // SPDX-FileCopyrightText: 2023 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
 // Software-Engineering: 2023 Intevation GmbH <https://intevation.de>
 
-// Package csaf contains the core data models used by the csaf distribution.
+// Package csaf contains the core data models used by the csaf distribution
+// tools.
+//
+// See https://github.com/gocsaf/csaf/tab=readme-ov-file#use-as-go-library
+// about hints and limits for its use as a library.
 package csaf
 
 //go:generate go run ./generate_cvss_enums.go -o cvss20enums.go -i ./schema/cvss-v2.0.json -p CVSS20

--- a/csaf/generate_cvss_enums.go
+++ b/csaf/generate_cvss_enums.go
@@ -12,7 +12,6 @@ package main
 
 import (
 	"bytes"
-	"encoding/json"
 	"flag"
 	"fmt"
 	"go/format"
@@ -22,6 +21,8 @@ import (
 	"sort"
 	"strings"
 	"text/template"
+
+	"github.com/gocsaf/csaf/v3/internal/misc"
 )
 
 // We from Intevation consider the source code parts in the following
@@ -98,7 +99,7 @@ func loadSchema(filename string) (*schema, error) {
 	}
 	defer f.Close()
 	var s schema
-	if err := json.NewDecoder(f).Decode(&s); err != nil {
+	if err := misc.StrictJSONParse(f, &s); err != nil {
 		return nil, err
 	}
 	return &s, nil

--- a/csaf/models.go
+++ b/csaf/models.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/gocsaf/csaf/v3/internal/misc"
 	"github.com/gocsaf/csaf/v3/util"
 )
 
@@ -575,7 +576,6 @@ func (d *Distribution) Validate() error {
 // Validate checks if the provider metadata is valid.
 // Returns an error if the validation fails otherwise nil.
 func (pmd *ProviderMetadata) Validate() error {
-
 	switch {
 	case pmd.CanonicalURL == nil:
 		return errors.New("canonical_url is mandatory")
@@ -695,8 +695,7 @@ func (pmd *ProviderMetadata) WriteTo(w io.Writer) (int64, error) {
 func LoadProviderMetadata(r io.Reader) (*ProviderMetadata, error) {
 
 	var pmd ProviderMetadata
-	dec := json.NewDecoder(r)
-	if err := dec.Decode(&pmd); err != nil {
+	if err := misc.StrictJSONParse(r, &pmd); err != nil {
 		return nil, err
 	}
 

--- a/csaf/providermetaloader.go
+++ b/csaf/providermetaloader.go
@@ -11,13 +11,13 @@ package csaf
 import (
 	"bytes"
 	"crypto/sha256"
-	"encoding/json"
 	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
 	"strings"
 
+	"github.com/gocsaf/csaf/v3/internal/misc"
 	"github.com/gocsaf/csaf/v3/util"
 )
 
@@ -33,7 +33,7 @@ type ProviderMetadataLoader struct {
 type ProviderMetadataLoadMessageType int
 
 const (
-	//JSONDecodingFailed indicates problems with JSON decoding
+	// JSONDecodingFailed indicates problems with JSON decoding
 	JSONDecodingFailed ProviderMetadataLoadMessageType = iota
 	// SchemaValidationFailed indicates a general problem with schema validation.
 	SchemaValidationFailed
@@ -149,7 +149,6 @@ func (pmdl *ProviderMetadataLoader) Enumerate(domain string) []*LoadedProviderMe
 	}
 	dnsURL := "https://csaf.data.security." + domain
 	return []*LoadedProviderMetadata{pmdl.loadFromURL(dnsURL)}
-
 }
 
 // Load loads one valid provider metadata for a given path.
@@ -323,7 +322,7 @@ func (pmdl *ProviderMetadataLoader) loadFromURL(path string) *LoadedProviderMeta
 
 	var doc any
 
-	if err := json.NewDecoder(tee).Decode(&doc); err != nil {
+	if err := misc.StrictJSONParse(tee, &doc); err != nil {
 		result.Messages.Add(
 			JSONDecodingFailed,
 			fmt.Sprintf("JSON decoding failed: %v", err))

--- a/csaf/remotevalidation.go
+++ b/csaf/remotevalidation.go
@@ -18,6 +18,7 @@ import (
 	"net/http"
 	"sync"
 
+	"github.com/gocsaf/csaf/v3/internal/misc"
 	bolt "go.etcd.io/bbolt"
 )
 
@@ -180,7 +181,6 @@ func prepareCache(config string) (cache, error) {
 			return create()
 		}
 		return nil
-
 	}); err != nil {
 		db.Close()
 		return nil, err
@@ -256,7 +256,7 @@ func deserialize(value []byte) (*RemoteValidationResult, error) {
 	}
 	defer r.Close()
 	var rvr RemoteValidationResult
-	if err := json.NewDecoder(r).Decode(&rvr); err != nil {
+	if err := misc.StrictJSONParse(r, &rvr); err != nil {
 		return nil, err
 	}
 	return &rvr, nil
@@ -323,7 +323,7 @@ func (v *remoteValidator) Validate(doc any) (*RemoteValidationResult, error) {
 			// no cache -> process directly.
 			in = resp.Body
 		}
-		return json.NewDecoder(in).Decode(&rvr)
+		return misc.StrictJSONParse(in, &rvr)
 	}(); err != nil {
 		return nil, err
 	}

--- a/csaf/rolie.go
+++ b/csaf/rolie.go
@@ -14,6 +14,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/gocsaf/csaf/v3/internal/misc"
 	"github.com/gocsaf/csaf/v3/util"
 )
 
@@ -54,7 +55,7 @@ type ROLIEServiceDocument struct {
 // LoadROLIEServiceDocument loads a ROLIE service document from a reader.
 func LoadROLIEServiceDocument(r io.Reader) (*ROLIEServiceDocument, error) {
 	var rsd ROLIEServiceDocument
-	if err := json.NewDecoder(r).Decode(&rsd); err != nil {
+	if err := misc.StrictJSONParse(r, &rsd); err != nil {
 		return nil, err
 	}
 	return &rsd, nil
@@ -122,7 +123,7 @@ func (rcd *ROLIECategoryDocument) Merge(categories ...string) bool {
 // LoadROLIECategoryDocument loads a ROLIE category document from a reader.
 func LoadROLIECategoryDocument(r io.Reader) (*ROLIECategoryDocument, error) {
 	var rcd ROLIECategoryDocument
-	if err := json.NewDecoder(r).Decode(&rcd); err != nil {
+	if err := misc.StrictJSONParse(r, &rcd); err != nil {
 		return nil, err
 	}
 	return &rcd, nil
@@ -195,9 +196,8 @@ type ROLIEFeed struct {
 
 // LoadROLIEFeed loads a ROLIE feed from a reader.
 func LoadROLIEFeed(r io.Reader) (*ROLIEFeed, error) {
-	dec := json.NewDecoder(r)
 	var rf ROLIEFeed
-	if err := dec.Decode(&rf); err != nil {
+	if err := misc.StrictJSONParse(r, &rf); err != nil {
 		return nil, err
 	}
 	return &rf, nil

--- a/docs/csaf_aggregator.md
+++ b/docs/csaf_aggregator.md
@@ -247,3 +247,9 @@ insecure = true
 In case you want to provide CSAF advisories from others
 that only qualify as CSAF publishers, see
 [how to use the `csaf_aggregator` as "CSAF proxy provider"](proxy-provider-for-aggregator.md).
+
+Some providers may limit the rate of requests that may be sent to retrieve advisories.
+This may cause issues with the aggregator. 
+In this case, the --rate option can be used to adjust the requests per second
+sent by each worker of the aggregator to an acceptable rate.
+(The rate that is considered acceptable depends on the provider.)

--- a/docs/csaf_checker.md
+++ b/docs/csaf_checker.md
@@ -78,6 +78,13 @@ The option `timerange` allows to only check advisories from a given time
 interval. It can only be given once. See the
 [downloader documentation](csaf_downloader.md#timerange-option) for details.
 
+Some providers may limit the rate of requests that may be sent to retrieve advisories.
+This may cause the checker to be unable to retrieve all advisories. In this case,
+the --rate option can be used to adjust the requests per second
+sent by the checker to an acceptable rate.
+(The rate that is considered acceptable depends on the provider.)
+
+
 You can ignore certain advisories while checking by specifying a list
 of regular expressions[^1] to match their URLs by using the `ignorepattern`
 option.

--- a/docs/csaf_downloader.md
+++ b/docs/csaf_downloader.md
@@ -51,6 +51,12 @@ to download more advisories at once. This may improve the overall speed of the d
 However, since this also increases the load on the servers, their administrators could
 have taken countermeasures to limit this.
 
+For example, some providers may limit the rate of requests that may be sent to retrieve advisories.
+This may cause the downloader to be unable to retrieve all advisories. 
+In this case, the --rate option can be used to adjust the requests per second
+sent by the downloader to an acceptable rate.
+(The rate that is considered acceptable depends on the provider.)
+
 If no config file is explictly given the follwing places are searched for a config file:
 
 ```
@@ -104,8 +110,9 @@ ignorepattern = [".*white.*", ".*red.*"]
 
 #### Timerange option
 
-The `timerange` parameter enables downloading advisories which last changes falls
-into a given intervall. There are three possible notations:
+The `time_range` parameter enables downloading advisories
+which last changes falls into a given intervall.
+There are three possible notations:
 
 1. Relative. If the given string follows the rules of a
    [Go duration](https://pkg.go.dev/time@go1.20.6#ParseDuration),

--- a/docs/csaf_provider.md
+++ b/docs/csaf_provider.md
@@ -58,7 +58,8 @@ The following example file documents all available configuration options:
 # The following shows an example of a manually set prefix:
 #canonical_url_prefix  = "https://localhost"
 
-# Require users to use a password and a valid Client Certificate for write access.
+# Require users to use both
+# (1) a password and (2) a valid Client Certificate for write access.
 #certificate_and_password = false
 
 # Allow the user to send the request without having to send a passphrase

--- a/docs/provider-setup.md
+++ b/docs/provider-setup.md
@@ -144,7 +144,7 @@ on a GNU/Linux operating system.
 
 Create the folders:
 ```(shell)
-curl https://192.168.56.102/cgi-bin/csaf_provider.go/create --cert-type p12 --cert {clientCertificat.p12}
+curl https://192.168.56.102/cgi-bin/csaf_provider.go/api/create --cert-type p12 --cert {clientCertificat.p12}
 ```
 Replace {clientCertificate.p12} with the client certificate file
 in pkcs12 format which includes the corresponding key as well.

--- a/docs/scripts/Readme.md
+++ b/docs/scripts/Readme.md
@@ -1,5 +1,5 @@
 Scripts for assisting the Integration tests.
-They were written on Ubuntu 20.04 TLS amd64 and also tested with 24.04 TLS.
+They were written on Ubuntu 20.04 LTS amd64 and also tested with 24.04 LTS.
 
 - `prepareUbuntuInstanceForITests.sh` installs the required packages for the csaf integration tests on a naked Ubuntu LTS amd64.
 
@@ -8,9 +8,9 @@ and configures nginx for serving TLS connections.
 
 - `TLSClientConfigsForITest.sh` generates client certificates by calling `createCCForITest.sh` which uses the root certificate initialized before with `createRootCAForITest.sh`. It configures nginx to enable the authentication with client certificate. (This assumes that the same folder name is used to create the root certificate)
 
-- `setupProviderForITest.sh` builds the csaf_provider, writes the required nginx configurations and create the initial folders. IT calls `uploadToProvider.sh` to upload some csaf example files to the provider.
+- `setupProviderForITest.sh` builds the `csaf_provider`, writes the required nginx configurations and create the initial folders. IT calls `uploadToProvider.sh` to upload some csaf example files to the provider.
 
-As creating the folders needs to authenticate with the csaf_provider, the configurations of TLS server and Client certificate authentication should be set. So it is recommended to call the scripts in this order: `TLSConfigsForITest.sh`, `TLSClientConfigsForITest.sh`, `setupProviderForITest.sh`
+As creating the folders needs to authenticate with the `csaf_provider`, the configurations of TLS server and Client certificate authentication should be set. So it is recommended to call the scripts in this order: `TLSConfigsForITest.sh`, `TLSClientConfigsForITest.sh`, `setupProviderForITest.sh`
 
 Calling example (as user with sudo privileges):
 ``` bash

--- a/internal/misc/json.go
+++ b/internal/misc/json.go
@@ -1,0 +1,35 @@
+// This file is Free Software under the Apache-2.0 License
+// without warranty, see README.md and LICENSES/Apache-2.0.txt for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: 2025 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+// Software-Engineering: 2025 Intevation GmbH <https://intevation.de>
+
+package misc
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// StrictJSONParse creates a JSON decoder that decodes an interface
+// while not allowing unknown fields nor trailing data
+func StrictJSONParse(jsonData io.Reader, target any) error {
+	decoder := json.NewDecoder(jsonData)
+
+	if err := decoder.Decode(target); err != nil {
+		return fmt.Errorf("JSON decoding error: %w", err)
+	}
+
+	// Check for any trailing data after the main JSON structure
+	if _, err := decoder.Token(); err != io.EOF {
+		if err != nil {
+			return fmt.Errorf("error reading trailing data: %w", err)
+		}
+		return fmt.Errorf("unexpected trailing data after JSON object")
+	}
+
+	return nil
+}

--- a/internal/misc/url.go
+++ b/internal/misc/url.go
@@ -1,0 +1,21 @@
+// This file is Free Software under the Apache-2.0 License
+// without warranty, see README.md and LICENSES/Apache-2.0.txt for details.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// SPDX-FileCopyrightText: 2025 German Federal Office for Information Security (BSI) <https://www.bsi.bund.de>
+// Software-Engineering: 2025 Intevation GmbH <https://intevation.de>
+
+package misc
+
+import "net/url"
+
+// JoinURL joins the two URLs while preserving the query and fragment part of the latter.
+func JoinURL(baseURL *url.URL, relativeURL *url.URL) *url.URL {
+	u := baseURL.JoinPath(relativeURL.Path)
+	u.RawQuery = relativeURL.RawQuery
+	u.RawFragment = relativeURL.RawFragment
+	// Enforce https, this is required if the base url was only a domain
+	u.Scheme = "https"
+	return u
+}

--- a/pkg/options/options.go
+++ b/pkg/options/options.go
@@ -46,7 +46,6 @@ type Parser[C any] struct {
 // If a config file was specified it is loaded.
 // Returns the arguments and the configuration.
 func (p *Parser[C]) Parse() ([]string, *C, error) {
-
 	var cmdLineOpts C
 	if p.SetDefaults != nil {
 		p.SetDefaults(&cmdLineOpts)
@@ -82,6 +81,7 @@ func (p *Parser[C]) Parse() ([]string, *C, error) {
 
 	// No config file -> We are good.
 	if path == "" {
+		slog.Warn("No config file found. Maybe you want to specify one or store it in a respective default location", "locations", p.DefaultConfigLocations)
 		return args, &cmdLineOpts, nil
 	}
 

--- a/testdata/csaf-documents/trailing-garbage-data/avendor-advisory-0004.json
+++ b/testdata/csaf-documents/trailing-garbage-data/avendor-advisory-0004.json
@@ -1,0 +1,171 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/v1/"
+      }
+    },
+    "notes": [
+      {
+        "category": "summary",
+        "title": "Test document summary",
+        "text": "Auto generated test CSAF document"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "ACME Inc.",
+      "namespace": "https://www.example.com"
+    },
+    "title": "Test CSAF document",
+    "tracking": {
+      "current_release_date": "2020-01-01T00:00:00Z",
+      "generator": {
+        "date": "2020-01-01T00:00:00Z",
+        "engine": {
+          "name": "csaf-tool",
+          "version": "0.3.2"
+        }
+      },
+      "id": "Avendor-advisory-0004",
+      "initial_release_date": "2020-01-01T00:00:00Z",
+      "revision_history": [
+        {
+          "date": "2020-01-01T00:00:00Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "AVendor",
+        "branches": [
+          {
+            "category": "product_name",
+            "name": "product_1",
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "1.1",
+                "product": {
+                  "name": "AVendor product_1 1.1",
+                  "product_id": "CSAFPID_0001"
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "1.2",
+                "product": {
+                  "name": "AVendor product_1 1.2",
+                  "product_id": "CSAFPID_0002"
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "2.0",
+                "product": {
+                  "name": "AVendor product_1 2.0",
+                  "product_id": "CSAFPID_0003"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "category": "vendor",
+        "name": "AVendor1",
+        "branches": [
+          {
+            "category": "product_name",
+            "name": "product_2",
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "1",
+                "product": {
+                  "name": "AVendor1 product_2 1",
+                  "product_id": "CSAFPID_0004"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "category": "vendor",
+        "name": "AVendor",
+        "branches": [
+          {
+            "category": "product_name",
+            "name": "product_3",
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "2022H2",
+                "product": {
+                  "name": "AVendor product_3 2022H2",
+                  "product_id": "CSAFPID_0005"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2020-1234",
+      "notes": [
+        {
+          "category": "description",
+          "title": "CVE description",
+          "text": "https://nvd.nist.gov/vuln/detail/CVE-2020-1234"
+        }
+      ],
+      "product_status": {
+        "under_investigation": ["CSAFPID_0001"]
+      },
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Customers should upgrade to the latest version of the product",
+          "date": "2020-01-01T00:00:00Z",
+          "product_ids": ["CSAFPID_0001"]
+        }
+      ]
+    },
+    {
+      "cve": "CVE-2020-9876",
+      "notes": [
+        {
+          "category": "description",
+          "title": "CVE description",
+          "text": "https://nvd.nist.gov/vuln/detail/CVE-2020-9876"
+        }
+      ],
+      "product_status": {
+        "under_investigation": ["CSAFPID_0001"]
+      },
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Still under investigation",
+          "date": "2020-01-01T00:00:00Z",
+          "product_ids": ["CSAFPID_0001"]
+        }
+      ]
+    }
+  ]
+}
+invalid data

--- a/testdata/csaf-documents/valid/avendor-advisory-0004.json
+++ b/testdata/csaf-documents/valid/avendor-advisory-0004.json
@@ -1,0 +1,170 @@
+{
+  "document": {
+    "category": "csaf_vex",
+    "csaf_version": "2.0",
+    "distribution": {
+      "tlp": {
+        "label": "WHITE",
+        "url": "https://www.first.org/tlp/v1/"
+      }
+    },
+    "notes": [
+      {
+        "category": "summary",
+        "title": "Test document summary",
+        "text": "Auto generated test CSAF document"
+      }
+    ],
+    "publisher": {
+      "category": "vendor",
+      "name": "ACME Inc.",
+      "namespace": "https://www.example.com"
+    },
+    "title": "Test CSAF document",
+    "tracking": {
+      "current_release_date": "2020-01-01T00:00:00Z",
+      "generator": {
+        "date": "2020-01-01T00:00:00Z",
+        "engine": {
+          "name": "csaf-tool",
+          "version": "0.3.2"
+        }
+      },
+      "id": "Avendor-advisory-0004",
+      "initial_release_date": "2020-01-01T00:00:00Z",
+      "revision_history": [
+        {
+          "date": "2020-01-01T00:00:00Z",
+          "number": "1",
+          "summary": "Initial version"
+        }
+      ],
+      "status": "final",
+      "version": "1"
+    }
+  },
+  "product_tree": {
+    "branches": [
+      {
+        "category": "vendor",
+        "name": "AVendor",
+        "branches": [
+          {
+            "category": "product_name",
+            "name": "product_1",
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "1.1",
+                "product": {
+                  "name": "AVendor product_1 1.1",
+                  "product_id": "CSAFPID_0001"
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "1.2",
+                "product": {
+                  "name": "AVendor product_1 1.2",
+                  "product_id": "CSAFPID_0002"
+                }
+              },
+              {
+                "category": "product_version",
+                "name": "2.0",
+                "product": {
+                  "name": "AVendor product_1 2.0",
+                  "product_id": "CSAFPID_0003"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "category": "vendor",
+        "name": "AVendor1",
+        "branches": [
+          {
+            "category": "product_name",
+            "name": "product_2",
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "1",
+                "product": {
+                  "name": "AVendor1 product_2 1",
+                  "product_id": "CSAFPID_0004"
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "category": "vendor",
+        "name": "AVendor",
+        "branches": [
+          {
+            "category": "product_name",
+            "name": "product_3",
+            "branches": [
+              {
+                "category": "product_version",
+                "name": "2022H2",
+                "product": {
+                  "name": "AVendor product_3 2022H2",
+                  "product_id": "CSAFPID_0005"
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  },
+  "vulnerabilities": [
+    {
+      "cve": "CVE-2020-1234",
+      "notes": [
+        {
+          "category": "description",
+          "title": "CVE description",
+          "text": "https://nvd.nist.gov/vuln/detail/CVE-2020-1234"
+        }
+      ],
+      "product_status": {
+        "under_investigation": ["CSAFPID_0001"]
+      },
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Customers should upgrade to the latest version of the product",
+          "date": "2020-01-01T00:00:00Z",
+          "product_ids": ["CSAFPID_0001"]
+        }
+      ]
+    },
+    {
+      "cve": "CVE-2020-9876",
+      "notes": [
+        {
+          "category": "description",
+          "title": "CVE description",
+          "text": "https://nvd.nist.gov/vuln/detail/CVE-2020-9876"
+        }
+      ],
+      "product_status": {
+        "under_investigation": ["CSAFPID_0001"]
+      },
+      "threats": [
+        {
+          "category": "impact",
+          "details": "Still under investigation",
+          "date": "2020-01-01T00:00:00Z",
+          "product_ids": ["CSAFPID_0001"]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## What

Add upstream changes. 

Only functional change to CSAF Downloader was that it now rejects CSAF documents which contain trailing garbage data to the JSON: https://github.com/gocsaf/csaf/pull/655



## Why

Keep our fork up to date.