### PR TITLE
fix incorrect usage of formatted string

### DIFF
--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -536,7 +536,7 @@ func (p *processor) rolieFeedEntries(feed string) ([]csaf.AdvisoryFile, error) {
 	if len(errors) > 0 {
 		p.badProviderMetadata.error("%s: Validating against JSON schema failed:", feed)
 		for _, msg := range errors {
-			p.badProviderMetadata.error(strings.ReplaceAll(msg, `%`, `%%`))
+			p.badProviderMetadata.error("%s", strings.ReplaceAll(msg, `%`, `%%`))
 		}
 	}
 
@@ -736,7 +736,7 @@ func (p *processor) integrity(
 
 		switch date, fault := p.extractTime(doc, `initial_release_date`, u); {
 		case fault != "":
-			p.badFolders.error(fault)
+			p.badFolders.error("%s", fault)
 		case folderYear == nil:
 			p.badFolders.error("No year folder found in %s", u)
 		case date.UTC().Year() != *folderYear:
@@ -744,7 +744,7 @@ func (p *processor) integrity(
 		}
 		current, fault := p.extractTime(doc, `current_release_date`, u)
 		if fault != "" {
-			p.badChanges.error(fault)
+			p.badChanges.error("%s", fault)
 		} else {
 			p.timesAdv[f.URL()] = current
 		}
@@ -814,7 +814,7 @@ func (p *processor) integrity(
 			msgType = InfoType
 		}
 		for _, fetchError := range hashFetchErrors {
-			p.badIntegrities.add(msgType, fetchError)
+			p.badIntegrities.add(msgType, "%s", fetchError)
 		}
 
 		// Check signature
@@ -1052,7 +1052,7 @@ func (p *processor) checkChanges(base string, mask whereType) error {
 		if p.cfg.Range != nil {
 			filtered = " (maybe filtered out by time interval)"
 		}
-		p.badChanges.warn("no entries in changes.csv found" + filtered)
+		p.badChanges.warn("%s", "no entries in changes.csv found"+filtered)
 	}
 
 	if !sort.SliceIsSorted(times, func(i, j int) bool {
@@ -1300,8 +1300,8 @@ func (p *processor) checkProviderMetadata(domain string) bool {
 
 	for i := range lpmd.Messages {
 		p.badProviderMetadata.warn(
-			"Unexpected situation while loading provider-metadata.json: " +
-				lpmd.Messages[i].Message)
+			"Unexpected situation while loading provider-metadata.json: %s",
+			lpmd.Messages[i].Message)
 	}
 
 	if !lpmd.Valid() {
@@ -1401,25 +1401,25 @@ func (p *processor) checkDNS(domain string) {
 	res, err := client.Get(path)
 	if err != nil {
 		p.badDNSPath.add(ErrorType,
-			fmt.Sprintf("Fetching %s failed: %v", path, err))
+			"Fetching %s failed: %v", path, err)
 		return
 	}
 	if res.StatusCode != http.StatusOK {
-		p.badDNSPath.add(ErrorType, fmt.Sprintf("Fetching %s failed. Status code %d (%s)",
-			path, res.StatusCode, res.Status))
+		p.badDNSPath.add(ErrorType, "Fetching %s failed. Status code %d (%s)",
+			path, res.StatusCode, res.Status)
 	}
 	hash := sha256.New()
 	defer res.Body.Close()
 	content, err := io.ReadAll(res.Body)
 	if err != nil {
 		p.badDNSPath.add(ErrorType,
-			fmt.Sprintf("Error while reading the response from %s", path))
+			"Error while reading the response from %s", path)
 	}
 	hash.Write(content)
 	if !bytes.Equal(hash.Sum(nil), p.pmd256) {
 		p.badDNSPath.add(ErrorType,
-			fmt.Sprintf("%s does not serve the same provider-metadata.json as previously found",
-				path))
+			"%s does not serve the same provider-metadata.json as previously found",
+			path)
 	}
 }
 
@@ -1433,12 +1433,11 @@ func (p *processor) checkWellknown(domain string) {
 	res, err := client.Get(path)
 	if err != nil {
 		p.badWellknownMetadata.add(ErrorType,
-			fmt.Sprintf("Fetching %s failed: %v", path, err))
-		return
+			"Fetching %s failed: %v", path, err)
 	}
 	if res.StatusCode != http.StatusOK {
-		p.badWellknownMetadata.add(ErrorType, fmt.Sprintf("Fetching %s failed. Status code %d (%s)",
-			path, res.StatusCode, res.Status))
+		p.badWellknownMetadata.add(ErrorType, "Fetching %s failed. Status code %d (%s)",
+			path, res.StatusCode, res.Status)
 	}
 }
 
@@ -1475,13 +1474,13 @@ func (p *processor) checkWellknownSecurityDNS(domain string) error {
 	// but found in the legacy location, and inform about finding it there (2).
 	switch warnings {
 	case 0:
-		p.badSecurity.add(InfoType, sDMessage)
+		p.badSecurity.add(InfoType, "%s", sDMessage)
 	case 1:
-		p.badSecurity.add(ErrorType, sDMessage)
-		p.badSecurity.add(ErrorType, sLMessage)
+		p.badSecurity.add(ErrorType, "%s", sDMessage)
+		p.badSecurity.add(ErrorType, "%s", sLMessage)
 	case 2:
-		p.badSecurity.add(WarnType, sDMessage)
-		p.badSecurity.add(InfoType, sLMessage)
+		p.badSecurity.add(WarnType, "%s", sDMessage)
+		p.badSecurity.add(InfoType, "%s", sLMessage)
 	}
 
 	p.checkDNS(domain)

--- a/pkg/models/models_test.go
+++ b/pkg/models/models_test.go
@@ -81,7 +81,7 @@ func TestUnmarshalText(t *testing.T) {
 	byteSlice := []byte{'3', 'h'}
 	var emptySlice []byte
 	if testTimeRange.UnmarshalText(byteSlice) != nil {
-		t.Errorf(testTimeRange.UnmarshalText(byteSlice).Error())
+		t.Error(testTimeRange.UnmarshalText(byteSlice).Error())
 	}
 	if testTimeRange.UnmarshalText(emptySlice) == nil {
 		t.Errorf("Failure: UnmarshalText succeeded on invalid slice of bytes.")
@@ -104,10 +104,10 @@ func TestUnmarshalFlag(t *testing.T) {
 		time.Date(2009, time.November, 10, 23, 0, 0, 0, time.UTC),
 		time.Date(2010, time.November, 10, 23, 0, 0, 0, time.UTC))
 	if err := testTimeRange.UnmarshalFlag("3h"); err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 	if err := testTimeRange.UnmarshalFlag("2006-01-02T15:04:05"); err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 	if err := testTimeRange.UnmarshalFlag("2006-01-02T15:04:05a"); err == nil {
 		t.Errorf("Failure: Extracted time from invalid string")
@@ -119,7 +119,7 @@ func TestUnmarshalFlag(t *testing.T) {
 		t.Errorf("Failure: Extracted time from invalid string")
 	}
 	if err := testTimeRange.UnmarshalFlag("2006-01-02T15:04:05, 2007-01-02T15:04:05"); err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 }
 

--- a/pkg/options/options_test.go
+++ b/pkg/options/options_test.go
@@ -90,7 +90,7 @@ func TestParse(t *testing.T) {
 	cmd.Env = append(os.Environ(), "TEST_HELP=1")
 	err := cmd.Run()
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 
 	// test the version flag
@@ -104,7 +104,7 @@ func TestParse(t *testing.T) {
 	cmd.Env = append(os.Environ(), "TEST_VERSION=1")
 	err = cmd.Run()
 	if err != nil {
-		t.Fatalf(err.Error())
+		t.Fatal(err.Error())
 	}
 }
 
@@ -140,7 +140,7 @@ func TestLoadToml(t *testing.T) {
 		t.Errorf("Failure: Succeeded in parsing nonexistant parameter")
 	}
 	if err := loadTOML(&cfg, "data/config.toml"); err != nil {
-		t.Errorf(err.Error())
+		t.Error(err.Error())
 	}
 }
 


### PR DESCRIPTION
## What

fix incorrect usage of formatted string

output probably unchanged, but now `go vet` is happy that formatted strings are not misused

## Why

Go vet is a mandatory check and with the updated go version is has more findings.

## References

PR blocked by this: #89
