### PR TITLE
fix for code scanning alert no. 28: Log entries created from user input

### DIFF
--- a/util/client.go
+++ b/util/client.go
@@ -105,11 +105,19 @@ func (hc *HeaderClient) PostForm(url string, data url.Values) (*http.Response, e
 
 // log logs to a callback if given.
 func (lc *LoggingClient) log(method, url string) {
+	cleanUrl := sanitizeForLog(url)
 	if lc.Log != nil {
-		lc.Log(method, url)
+		lc.Log(method, cleanUrl)
 	} else {
-		log.Printf("[%s]: %s\n", method, url)
+		log.Printf("[%s]: %s\n", method, cleanUrl)
 	}
+}
+
+// sanitizeForLog removes line breaks to prevent log injection.
+func sanitizeForLog(s string) string {
+	s = strings.ReplaceAll(s, "\n", "")
+	s = strings.ReplaceAll(s, "\r", "")
+	return s
 }
 
 // Do implements the respective method of the Client interface.


### PR DESCRIPTION
Fix for [https://github.com/greenbone/csaf_distribution/security/code-scanning/28](https://github.com/greenbone/csaf_distribution/security/code-scanning/28)

To fix the issue, we need to ensure that any user-provided or untrusted value written to logs is properly sanitized. For plain text logs, the main attack vector is newlines (`\n`, `\r`), which allow an attacker to insert extra lines or otherwise forge log entries. Thus, every occurrence of user-provided data (in this case, the `url` variable/parameter) that enters logs should have all `\n` and `\r` characters removed or replaced.

To address this in the code, any value written as `log.Printf("[%s]: %s\n", method, url)` (or sent to the log callback as `lc.Log(method, url)`) must be sanitized first. The best way is to introduce an inline sanitization step—either in the `log` convenience method or just before logging/callback invocation.

We can create a small helper `sanitizeForLog()`, which uses `strings.ReplaceAll()` to strip `\n` and `\r`, and call it on `url` before writing to the log or passing to the callback. This way, all log invocations using user URLs are immune to log forging, and the change localizes the fix around the logging point.

Changes required (all in `util/client.go`):

- Define a helper for sanitization, e.g.,  
  ```go
  func sanitizeForLog(s string) string { ... }
  ```
- In `func (lc *LoggingClient) log(...)`, sanitize `url` before using.
- No external dependencies are required (uses Go stdlib).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
