### PR TITLE
fix incorrect usage of formatted string (more of them)

### DIFF
--- a/cmd/csaf_checker/processor.go
+++ b/cmd/csaf_checker/processor.go
@@ -254,14 +254,12 @@ func (p *processor) run(domains []string) (*Report, error) {
 		if !p.checkProviderMetadata(d) {
 			// We need to fail the domain if the PMD cannot be parsed.
 			p.badProviderMetadata.use()
-			message := fmt.Sprintf("Could not parse the Provider-Metadata.json of: %s", d)
-			p.badProviderMetadata.error(message)
+			p.badProviderMetadata.error("Could not parse the Provider-Metadata.json of: %s", d)
 
 		}
 		if err := p.checkDomain(d); err != nil {
 			p.badProviderMetadata.use()
-			message := fmt.Sprintf("Failed to find valid provider-metadata.json for domain %s: %v. ", d, err)
-			p.badProviderMetadata.error(message)
+			p.badProviderMetadata.error("Failed to find valid provider-metadata.json for domain %s: %v. ", d, err)
 		}
 		domain := &Domain{Name: d}
 


### PR DESCRIPTION
## What

fix incorrect usage of formatted string, newly introduced by #90 

output probably unchanged, but now `go vet` is happy that formatted strings are not misused

## Why

Go vet is a mandatory check and with the updated go version is has more findings.

## References

PR blocked by this: #89
